### PR TITLE
feat: Update ADB commands tool for Android 12+ focus

### DIFF
--- a/.github/ISSUE_TEMPLATE/adb_cmd_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/adb_cmd_bug_report.md
@@ -1,0 +1,56 @@
+---
+name: ADB Command Bug Report
+about: Report an issue with an existing ADB command
+title: '[ADB CMD BUG] '
+labels: 'adb-cmd, bug'
+assignees: ''
+---
+
+## Command Information
+**Command ID/Title:**
+<!-- e.g., "ID: 3 - Get Current Activity" -->
+
+**Platform:**
+- [ ] Windows
+- [ ] Mac/Linux
+- [ ] Both
+
+## Bug Description
+**What's wrong with the command?**
+<!-- Describe the issue with the command -->
+
+## Expected Behavior
+**What should the command do?**
+<!-- Describe what you expected to happen -->
+
+## Actual Behavior
+**What does the command actually do?**
+<!-- Describe what actually happened -->
+
+## Error Output
+```
+<!-- Paste any error messages here -->
+```
+
+## Android Version Information
+**Tested on Android Version(s):**
+<!-- e.g., Android 14 (API 34) -->
+
+**Device/Emulator:**
+<!-- e.g., Pixel 7, Android Emulator -->
+
+## Suggested Fix
+**If you know the correct command, please provide it:**
+```bash
+# For Windows:
+
+# For Mac/Linux:
+```
+
+## Additional Context
+<!-- Add any other context about the problem here -->
+
+## Verification
+- [ ] I have tested this on Android 12 or higher
+- [ ] I have verified the command fails consistently
+- [ ] I have checked that developer options and ADB debugging are enabled

--- a/.github/ISSUE_TEMPLATE/adb_cmd_new_command.md
+++ b/.github/ISSUE_TEMPLATE/adb_cmd_new_command.md
@@ -1,0 +1,91 @@
+---
+name: New ADB Command Request
+about: Suggest a new ADB command to add to the tool
+title: '[NEW CMD] '
+labels: 'adb-cmd, enhancement'
+assignees: ''
+---
+
+## Command Details
+
+**Command Title:**
+<!-- e.g., "Enable Developer Options" -->
+
+**Category:**
+- [ ] Connection
+- [ ] Device Info
+- [ ] Installation
+- [ ] Troubleshooting
+- [ ] Other (please specify): ___________
+
+**Command Syntax:**
+
+### Windows:
+```bash
+# Windows command here
+```
+
+### Mac/Linux:
+```bash
+# Mac/Linux command here
+```
+
+## Command Description
+**What does this command do?**
+<!-- Provide a clear description of what the command accomplishes -->
+
+## Use Case
+**When would someone use this command?**
+<!-- Explain the scenario or problem this command helps solve -->
+
+## Android Version Compatibility
+**Minimum Android Version:**
+- [ ] Android 12 (API 31)
+- [ ] Android 13 (API 33)
+- [ ] Android 14 (API 34)
+- [ ] Android 15 (API 35)
+- [ ] Android 16 (API 36)
+- [ ] All versions from Android 12+
+
+**Version-Specific Notes:**
+<!-- If the command behaves differently on different Android versions, explain here -->
+
+## Testing & Verification
+
+**Have you tested this command?**
+- [ ] Yes, I have personally tested this command
+- [ ] No, but I have documentation/references
+
+**Tested on:**
+- Android Version(s):
+- Device(s):
+
+**Test Output:**
+```
+<!-- Paste successful command output here -->
+```
+
+## Additional Information
+
+**Documentation/References:**
+<!-- Provide links to official Android documentation or other references -->
+
+**Related Commands:**
+<!-- List any related commands already in the tool that this complements -->
+
+## Prerequisites
+<!-- List any requirements (e.g., root access, specific permissions, developer options) -->
+- [ ] Developer Options enabled
+- [ ] USB Debugging enabled
+- [ ] Wireless Debugging enabled
+- [ ] Root access required
+- [ ] Other: ___________
+
+## Notes for EMM/Enterprise Use
+<!-- If this command is particularly useful for EMM admins or enterprise scenarios, explain here -->
+
+---
+**By submitting this request, I confirm that:**
+- [ ] This command is not already in the ADB Commands tool
+- [ ] This command works on Android 12 or higher
+- [ ] This command serves a practical purpose for developers/EMM admins

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# System files
+.DS_Store
+Thumbs.db
+
+# Claude Code settings
+.claude/
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+venv/
+env/
+ENV/
+.venv
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*.swn
+
+# Temporary files
+*.tmp
+*.bak
+*.backup
+*~
+
+# Logs
+*.log
+logs/

--- a/tools/adb-cmd/data/backups/commands_20251110_195423.json
+++ b/tools/adb-cmd/data/backups/commands_20251110_195423.json
@@ -1,0 +1,516 @@
+[
+    {
+      "id": 1,
+      "title": "List Connected Devices",
+      "windows": "adb devices",
+      "mac": "adb devices",
+      "description": "Shows all devices/emulators connected to your computer. This is usually the first command to run to verify your device is properly connected.",
+      "category": "connection",
+      "androidVersions": {
+        "min": "All",
+        "max": "All",
+        "notes": "Core ADB command that works across all Android versions"
+      },
+      "verification": {
+        "verified": false,
+        "lastTested": null,
+        "testedVersions": {}
+      }
+    },
+    {
+      "id": 2,
+      "title": "Connect to Device over WiFi",
+      "windows": "adb connect ip_address:port",
+      "mac": "adb connect ip_address:port",
+      "description": "Connects to a device over WiFi instead of USB. You'll need to know the device's IP address, and it must be on the same network as your computer. Default port is 5555.",
+      "category": "connection",
+      "androidVersions": {
+        "min": "4.0",
+        "max": "All",
+        "notes": "Requires developer options enabled and ADB debugging turned on"
+      },
+      "verification": {
+        "verified": false,
+        "lastTested": null,
+        "testedVersions": {}
+      }
+    },
+    {
+      "id": 3,
+      "title": "Get Current Activity (Foreground App)",
+      "description": "Shows the current activity that's in the foreground. Useful for debugging or automation to determine what's currently visible on screen.",
+      "category": "deviceinfo",
+      "multiVersion": true,
+      "versions": [
+        {
+          "range": "4.0 - 10.0",
+          "windows": "adb shell dumpsys window windows | grep -E 'mCurrentFocus|mFocusedApp'",
+          "mac": "adb shell dumpsys window windows | grep -E 'mCurrentFocus|mFocusedApp'",
+          "notes": "Uses window service dumpsys to find the current focused window/activity",
+          "verification": {
+            "verified": false,
+            "lastTested": null,
+            "testedVersions": {}
+          }
+        },
+        {
+          "range": "11",
+          "windows": "adb shell dumpsys window | grep -E 'name=.* topActivity'",
+          "mac": "adb shell dumpsys window | grep -E 'name=.* topActivity'",
+          "notes": "Android 11 changed the output format of window service dumpsys",
+          "verification": {
+            "verified": false,
+            "lastTested": null,
+            "testedVersions": {}
+          }
+        },
+        {
+          "range": "12+",
+          "windows": "adb shell dumpsys activity recents",
+          "mac": "adb shell dumpsys activity recents",
+          "notes": "For Android 12+, use the activity recents command to get detailed info including PIP mode activities",
+          "verification": {
+            "verified": false,
+            "lastTested": null,
+            "testedVersions": {}
+          }
+        }
+      ],
+      "verification": {
+        "verified": false,
+        "lastTested": null,
+        "overallStatus": "untested"
+      }
+    },
+    {
+      "id": 4,
+      "title": "Check Package Info",
+      "description": "Gets detailed information about a specific package (app), including version, install time, and permissions.",
+      "category": "deviceinfo",
+      "multiVersion": true,
+      "versions": [
+        {
+          "range": "4.0 - 6.0",
+          "windows": "adb shell dumpsys package com.example.app",
+          "mac": "adb shell dumpsys package com.example.app",
+          "notes": "Basic package information"
+        },
+        {
+          "range": "7.0 - 9.0",
+          "windows": "adb shell dumpsys package com.example.app | grep -E 'versionName|firstInstallTime|lastUpdateTime'",
+          "mac": "adb shell dumpsys package com.example.app | grep -E 'versionName|firstInstallTime|lastUpdateTime'",
+          "notes": "Filtered output to show most relevant information"
+        },
+        {
+          "range": "10+",
+          "windows": "adb shell pm dump com.example.app",
+          "mac": "adb shell pm dump com.example.app",
+          "notes": "Android 10+ offers more specific package manager commands to get cleaner output"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Get Device Screenshot",
+      "description": "Captures a screenshot of the device screen and saves it to your computer.",
+      "category": "troubleshooting",
+      "multiVersion": true,
+      "versions": [
+        {
+          "range": "4.0 - 4.3",
+          "windows": "adb shell screencap -p /sdcard/screenshot.png && adb pull /sdcard/screenshot.png && adb shell rm /sdcard/screenshot.png",
+          "mac": "adb shell screencap -p /sdcard/screenshot.png && adb pull /sdcard/screenshot.png && adb shell rm /sdcard/screenshot.png",
+          "notes": "Basic two-step process with cleanup"
+        },
+        {
+          "range": "4.4+",
+          "windows": "adb exec-out screencap -p > screenshot.png",
+          "mac": "adb exec-out screencap -p > screenshot.png",
+          "notes": "More efficient single-command process using exec-out (added in Android 4.4)"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Install APK",
+      "windows": "adb install path\\to\\app.apk",
+      "mac": "adb install path/to/app.apk",
+      "description": "Installs an APK file onto the connected device. Add the '-r' flag to replace an existing application.",
+      "category": "installation",
+      "androidVersions": {
+        "min": "All",
+        "max": "All",
+        "notes": "Core ADB command that works across all Android versions"
+      }
+    },
+    {
+      "id": 7,
+      "title": "Install APK to Specific User",
+      "windows": "adb install --user user_id path\\to\\app.apk",
+      "mac": "adb install --user user_id path/to/app.apk",
+      "description": "Installs an APK for a specific user on a multi-user device. Particularly useful in enterprise environments with work profiles.",
+      "category": "installation",
+      "androidVersions": {
+        "min": "4.4",
+        "max": "All",
+        "notes": "Requires multi-user support, which began in Android 4.4 (KitKat)"
+      }
+    },
+    {
+      "id": 8,
+      "title": "Check Battery Stats",
+      "description": "Shows detailed information about the device's battery status and usage.",
+      "category": "deviceinfo",
+      "multiVersion": true,
+      "versions": [
+        {
+          "range": "4.0 - 7.0",
+          "windows": "adb shell dumpsys battery",
+          "mac": "adb shell dumpsys battery",
+          "notes": "Basic battery information"
+        },
+        {
+          "range": "8.0 - 9.0",
+          "windows": "adb shell dumpsys batterystats",
+          "mac": "adb shell dumpsys batterystats",
+          "notes": "Enhanced battery stats with usage by app introduced in Oreo"
+        },
+        {
+          "range": "10+",
+          "windows": "adb shell dumpsys batterystats --charged",
+          "mac": "adb shell dumpsys batterystats --charged",
+          "notes": "More detailed battery usage stats with additional parameters available"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "title": "Uninstall App",
+      "windows": "adb uninstall com.example.app",
+      "mac": "adb uninstall com.example.app",
+      "description": "Removes an app from the device. You need to specify the package name, not the app name.",
+      "category": "installation",
+      "androidVersions": {
+        "min": "All",
+        "max": "All",
+        "notes": "Core ADB command that works across all Android versions"
+      }
+    },
+    {
+      "id": 10,
+      "title": "Wireless Debugging Setup",
+      "description": "Sets up wireless debugging to connect to your device over WiFi instead of USB.",
+      "category": "connection",
+      "multiVersion": true,
+      "versions": [
+        {
+          "range": "4.0 - 10.0",
+          "windows": "adb tcpip 5555 && adb shell ip addr show wlan0 | findstr \"inet\" && adb connect [device_ip]:5555",
+          "mac": "adb tcpip 5555 && adb shell ip addr show wlan0 | grep inet && adb connect [device_ip]:5555",
+          "notes": "Traditional method requiring initial USB connection"
+        },
+        {
+          "range": "11+",
+          "windows": "adb pair [ip_address]:[pairing_port]",
+          "mac": "adb pair [ip_address]:[pairing_port]",
+          "notes": "Android 11+ supports secure pairing. Enable \"Wireless debugging\" in Developer options to get pairing code."
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "title": "Backup Device",
+      "windows": "adb backup -apk -shared -all -f backup_file.ab",
+      "mac": "adb backup -apk -shared -all -f backup_file.ab",
+      "description": "Creates a full backup of the device. Not all devices support this feature, especially newer Android versions with work profiles.",
+      "category": "deviceinfo",
+      "androidVersions": {
+        "min": "4.0",
+        "max": "10.0",
+        "notes": "Functionality limited after Android 9, deprecated since Android 10. No longer reliable on newer devices."
+      }
+    },
+    {
+      "id": 12,
+      "title": "View Device Logs",
+      "windows": "adb logcat",
+      "mac": "adb logcat",
+      "description": "Shows real-time logs from the device. Useful for debugging crashes or unexpected behavior. Use Ctrl+C to stop.",
+      "category": "troubleshooting",
+      "androidVersions": {
+        "min": "All",
+        "max": "All",
+        "notes": "Core ADB command that works across all Android versions"
+      }
+    },
+    {
+      "id": 13,
+      "title": "Force Stop App",
+      "description": "Forces an app to stop running. Useful when an app is unresponsive or for testing app recovery.",
+      "category": "troubleshooting",
+      "multiVersion": true,
+      "versions": [
+        {
+          "range": "All",
+          "windows": "adb shell am force-stop com.example.app",
+          "mac": "adb shell am force-stop com.example.app",
+          "notes": "Basic force stop command"
+        },
+        {
+          "range": "9.0+",
+          "windows": "adb shell am kill com.example.app",
+          "mac": "adb shell am kill com.example.app",
+          "notes": "Alternative method that kills the process but may allow background services to restart"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "title": "Get Device Model",
+      "windows": "adb shell getprop ro.product.model",
+      "mac": "adb shell getprop ro.product.model",
+      "description": "Retrieves the model name of the connected device. Helpful for documentation or ensuring compatibility.",
+      "category": "deviceinfo",
+      "androidVersions": {
+        "min": "All",
+        "max": "All",
+        "notes": "Core property available on all Android versions"
+      }
+    },
+    {
+      "id": 15,
+      "title": "Get Android Version",
+      "windows": "adb shell getprop ro.build.version.release",
+      "mac": "adb shell getprop ro.build.version.release",
+      "description": "Displays the Android version (e.g., 13.0) running on the device.",
+      "category": "deviceinfo",
+      "androidVersions": {
+        "min": "All",
+        "max": "All",
+        "notes": "Core property available on all Android versions"
+      }
+    },
+    {
+      "id": 16,
+      "title": "Get Enterprise Info (Work Profile)",
+      "description": "Gets information about enterprise provisioning and work profile status.",
+      "category": "deviceinfo",
+      "multiVersion": true,
+      "versions": [
+        {
+          "range": "5.0 - 8.0",
+          "windows": "adb shell dumpsys device_policy",
+          "mac": "adb shell dumpsys device_policy",
+          "notes": "Basic device policy information for Android Lollipop through Oreo"
+        },
+        {
+          "range": "9.0 - 11.0",
+          "windows": "adb shell dumpsys device_policy | findstr \"Profile Owner\"",
+          "mac": "adb shell dumpsys device_policy | grep \"Profile Owner\"",
+          "notes": "Filtered output to check for profile owner and work profile"
+        },
+        {
+          "range": "12+",
+          "windows": "adb shell dumpsys device_policy | findstr -i \"owner|profile\"",
+          "mac": "adb shell dumpsys device_policy | grep -i \"owner\\|profile\"",
+          "notes": "More detailed grep to handle format changes in Android 12+"
+        }
+      ]
+    },
+    {
+      "id": 17,
+      "title": "Get Package List",
+      "windows": "adb shell pm list packages",
+      "mac": "adb shell pm list packages",
+      "description": "Lists all installed packages on the device. Add '-s' for system apps only or '-3' for user-installed apps only.",
+      "category": "deviceinfo",
+      "androidVersions": {
+        "min": "All",
+        "max": "All",
+        "notes": "Core package manager command available on all Android versions"
+      }
+    },
+    {
+      "id": 18,
+      "title": "Start Activity Manager",
+      "windows": "adb shell am start -n com.package.name/com.package.name.ActivityName",
+      "mac": "adb shell am start -n com.package.name/com.package.name.ActivityName",
+      "description": "Launches a specific activity within an app. Useful for debugging or automating specific screens.",
+      "category": "troubleshooting",
+      "androidVersions": {
+        "min": "All",
+        "max": "All",
+        "notes": "Core activity manager command available on all Android versions"
+      }
+    },
+    {
+      "id": 19,
+      "title": "Reboot Device",
+      "windows": "adb reboot",
+      "mac": "adb reboot",
+      "description": "Reboots the connected device. Useful when troubleshooting or after making system-level changes.",
+      "category": "troubleshooting",
+      "androidVersions": {
+        "min": "All",
+        "max": "All",
+        "notes": "Core ADB command that works across all Android versions"
+      }
+    },
+    {
+      "id": 20,
+      "title": "Record Screen",
+      "windows": "adb shell screenrecord /sdcard/recording.mp4",
+      "mac": "adb shell screenrecord /sdcard/recording.mp4",
+      "description": "Records the device screen as an MP4 video. Press Ctrl+C to stop recording, then use 'adb pull' to retrieve the file.",
+      "category": "troubleshooting",
+      "androidVersions": {
+        "min": "4.4",
+        "max": "All",
+        "notes": "Screen recording was introduced in Android 4.4 (KitKat)"
+      }
+    },
+    {
+      "id": 21,
+      "title": "Copy Files to Device",
+      "windows": "adb push local_file.txt /sdcard/",
+      "mac": "adb push local_file.txt /sdcard/",
+      "description": "Transfers a file from your computer to the device storage. Useful for testing or deploying configuration files.",
+      "category": "troubleshooting",
+      "androidVersions": {
+        "min": "All",
+        "max": "All",
+        "notes": "Core ADB command that works across all Android versions"
+      }
+    },
+    {
+      "id": 22,
+      "title": "Copy Files from Device",
+      "windows": "adb pull /sdcard/file.txt local_folder/",
+      "mac": "adb pull /sdcard/file.txt local_folder/",
+      "description": "Retrieves a file from the device to your computer. Essential for collecting logs or other generated files.",
+      "category": "troubleshooting",
+      "androidVersions": {
+        "min": "All",
+        "max": "All",
+        "notes": "Core ADB command that works across all Android versions"
+      }
+    },
+    {
+      "id": 23,
+      "title": "Check WiFi Status",
+      "windows": "adb shell dumpsys wifi",
+      "mac": "adb shell dumpsys wifi",
+      "description": "Provides comprehensive information about the device's WiFi connection, useful for network troubleshooting.",
+      "category": "deviceinfo",
+      "androidVersions": {
+        "min": "All",
+        "max": "All",
+        "notes": "Core dumpsys command available on all Android versions"
+      }
+    },
+    {
+      "id": 24,
+      "title": "Get Device Serial Number",
+      "windows": "adb shell getprop ro.serialno",
+      "mac": "adb shell getprop ro.serialno",
+      "description": "Retrieves the device's serial number. Important for inventory management or when managing multiple devices.",
+      "category": "deviceinfo",
+      "androidVersions": {
+        "min": "All",
+        "max": "All",
+        "notes": "Core property available on all Android versions"
+      }
+    },
+    {
+      "id": 25,
+      "title": "Send Text Input",
+      "windows": "adb shell input text \"your_text_here\"",
+      "mac": "adb shell input text \"your_text_here\"",
+      "description": "Types the specified text on the device. Helpful for automating text entry during testing or setup.",
+      "category": "troubleshooting",
+      "androidVersions": {
+        "min": "4.1",
+        "max": "All",
+        "notes": "Input subsystem commands became reliable from Android 4.1 (Jelly Bean)"
+      }
+    },
+    {
+      "id": 26,
+      "title": "Check Device Uptime",
+      "windows": "adb shell uptime",
+      "mac": "adb shell uptime",
+      "description": "Shows how long the device has been running since the last boot. Useful for stability testing or verifying recent reboots.",
+      "category": "deviceinfo",
+      "androidVersions": {
+        "min": "All",
+        "max": "All",
+        "notes": "Core Linux/Unix command available on all Android versions"
+      }
+    },
+    {
+      "id": 27,
+      "title": "Clear App Data",
+      "windows": "adb shell pm clear com.example.app",
+      "mac": "adb shell pm clear com.example.app",
+      "description": "Clears all data for a specified app (similar to clearing data in Settings). Helpful for troubleshooting app issues.",
+      "category": "troubleshooting",
+      "androidVersions": {
+        "min": "All",
+        "max": "All",
+        "notes": "Core package manager command available on all Android versions"
+      }
+    },
+    {
+      "id": 28,
+      "title": "Get Device IP Address",
+      "description": "Displays the IP address of the device's WiFi connection. Useful before setting up wireless debugging.",
+      "category": "connection",
+      "multiVersion": true,
+      "versions": [
+        {
+          "range": "4.0 - 4.4",
+          "windows": "adb shell netcfg | findstr wlan",
+          "mac": "adb shell netcfg | grep wlan",
+          "notes": "Legacy command for Android KitKat and earlier"
+        },
+        {
+          "range": "5.0 - 6.0",
+          "windows": "adb shell ifconfig wlan0",
+          "mac": "adb shell ifconfig wlan0",
+          "notes": "Traditional Unix ifconfig command works on Lollipop and Marshmallow"
+        },
+        {
+          "range": "7.0+",
+          "windows": "adb shell ip addr show wlan0",
+          "mac": "adb shell ip addr show wlan0",
+          "notes": "Modern format available since Android Nougat"
+        }
+      ]
+    },
+    {
+      "id": 29,
+      "title": "Grant App Permissions",
+      "windows": "adb shell pm grant com.example.app android.permission.PERMISSION_NAME",
+      "mac": "adb shell pm grant com.example.app android.permission.PERMISSION_NAME",
+      "description": "Grants a specific permission to an app. Useful for automating permission grants during testing.",
+      "category": "troubleshooting",
+      "androidVersions": {
+        "min": "6.0",
+        "max": "All",
+        "notes": "Runtime permissions were introduced in Android 6.0 (Marshmallow)"
+      }
+    },
+    {
+      "id": 30,
+      "title": "Revoke App Permissions",
+      "windows": "adb shell pm revoke com.example.app android.permission.PERMISSION_NAME",
+      "mac": "adb shell pm revoke com.example.app android.permission.PERMISSION_NAME",
+      "description": "Revokes a specific permission from an app. Useful for testing permission denial scenarios.",
+      "category": "troubleshooting",
+      "androidVersions": {
+        "min": "6.0",
+        "max": "All",
+        "notes": "Runtime permissions were introduced in Android 6.0 (Marshmallow)"
+      }
+    }
+  ]

--- a/tools/adb-cmd/data/commands.json
+++ b/tools/adb-cmd/data/commands.json
@@ -1,486 +1,665 @@
 [
-    {
-      "id": 1,
-      "title": "List Connected Devices",
-      "windows": "adb devices",
-      "mac": "adb devices",
-      "description": "Shows all devices/emulators connected to your computer. This is usually the first command to run to verify your device is properly connected.",
-      "category": "connection",
-      "androidVersions": {
-        "min": "All",
-        "max": "All",
-        "notes": "Core ADB command that works across all Android versions"
-      }
+  {
+    "id": 1,
+    "title": "List Connected Devices",
+    "windows": "adb devices",
+    "mac": "adb devices",
+    "description": "Shows all devices/emulators connected to your computer. This is usually the first command to run to verify your device is properly connected.",
+    "category": "connection",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Core ADB command that works across all Android versions"
     },
-    {
-      "id": 2,
-      "title": "Connect to Device over WiFi",
-      "windows": "adb connect ip_address:port",
-      "mac": "adb connect ip_address:port",
-      "description": "Connects to a device over WiFi instead of USB. You'll need to know the device's IP address, and it must be on the same network as your computer. Default port is 5555.",
-      "category": "connection",
-      "androidVersions": {
-        "min": "4.0",
-        "max": "All",
-        "notes": "Requires developer options enabled and ADB debugging turned on"
-      }
-    },
-    {
-      "id": 3,
-      "title": "Get Current Activity (Foreground App)",
-      "description": "Shows the current activity that's in the foreground. Useful for debugging or automation to determine what's currently visible on screen.",
-      "category": "deviceinfo",
-      "multiVersion": true,
-      "versions": [
-        {
-          "range": "4.0 - 10.0",
-          "windows": "adb shell dumpsys window windows | grep -E 'mCurrentFocus|mFocusedApp'",
-          "mac": "adb shell dumpsys window windows | grep -E 'mCurrentFocus|mFocusedApp'",
-          "notes": "Uses window service dumpsys to find the current focused window/activity"
+    "verification": {
+      "verified": true,
+      "lastTested": "2025-11-10",
+      "testedVersions": {
+        "36": {
+          "status": "pass",
+          "date": "2025-11-10",
+          "output": "List of devices attached\nemulator-5556   device\n",
+          "error": null,
+          "notes": null
         },
-        {
-          "range": "11",
-          "windows": "adb shell dumpsys window | grep -E 'name=.* topActivity'",
-          "mac": "adb shell dumpsys window | grep -E 'name=.* topActivity'",
-          "notes": "Android 11 changed the output format of window service dumpsys"
+        "35": {
+          "status": "pass",
+          "date": "2025-11-10",
+          "output": "List of devices attached\nemulator-5554\tdevice\n\n",
+          "error": null,
+          "notes": null
         },
-        {
-          "range": "12+",
-          "windows": "adb shell dumpsys activity recents",
-          "mac": "adb shell dumpsys activity recents",
-          "notes": "For Android 12+, use the activity recents command to get detailed info including PIP mode activities"
+        "34": {
+          "status": "pass",
+          "date": "2025-11-10",
+          "output": "List of devices attached\nemulator-5554\tdevice\n\n",
+          "error": null,
+          "notes": null
         }
-      ]
-    },
-    {
-      "id": 4,
-      "title": "Check Package Info",
-      "description": "Gets detailed information about a specific package (app), including version, install time, and permissions.",
-      "category": "deviceinfo",
-      "multiVersion": true,
-      "versions": [
-        {
-          "range": "4.0 - 6.0",
-          "windows": "adb shell dumpsys package com.example.app",
-          "mac": "adb shell dumpsys package com.example.app",
-          "notes": "Basic package information"
-        },
-        {
-          "range": "7.0 - 9.0",
-          "windows": "adb shell dumpsys package com.example.app | grep -E 'versionName|firstInstallTime|lastUpdateTime'",
-          "mac": "adb shell dumpsys package com.example.app | grep -E 'versionName|firstInstallTime|lastUpdateTime'",
-          "notes": "Filtered output to show most relevant information"
-        },
-        {
-          "range": "10+",
-          "windows": "adb shell pm dump com.example.app",
-          "mac": "adb shell pm dump com.example.app",
-          "notes": "Android 10+ offers more specific package manager commands to get cleaner output"
-        }
-      ]
-    },
-    {
-      "id": 5,
-      "title": "Get Device Screenshot",
-      "description": "Captures a screenshot of the device screen and saves it to your computer.",
-      "category": "troubleshooting",
-      "multiVersion": true,
-      "versions": [
-        {
-          "range": "4.0 - 4.3",
-          "windows": "adb shell screencap -p /sdcard/screenshot.png && adb pull /sdcard/screenshot.png && adb shell rm /sdcard/screenshot.png",
-          "mac": "adb shell screencap -p /sdcard/screenshot.png && adb pull /sdcard/screenshot.png && adb shell rm /sdcard/screenshot.png",
-          "notes": "Basic two-step process with cleanup"
-        },
-        {
-          "range": "4.4+",
-          "windows": "adb exec-out screencap -p > screenshot.png",
-          "mac": "adb exec-out screencap -p > screenshot.png",
-          "notes": "More efficient single-command process using exec-out (added in Android 4.4)"
-        }
-      ]
-    },
-    {
-      "id": 6,
-      "title": "Install APK",
-      "windows": "adb install path\\to\\app.apk",
-      "mac": "adb install path/to/app.apk",
-      "description": "Installs an APK file onto the connected device. Add the '-r' flag to replace an existing application.",
-      "category": "installation",
-      "androidVersions": {
-        "min": "All",
-        "max": "All",
-        "notes": "Core ADB command that works across all Android versions"
-      }
-    },
-    {
-      "id": 7,
-      "title": "Install APK to Specific User",
-      "windows": "adb install --user user_id path\\to\\app.apk",
-      "mac": "adb install --user user_id path/to/app.apk",
-      "description": "Installs an APK for a specific user on a multi-user device. Particularly useful in enterprise environments with work profiles.",
-      "category": "installation",
-      "androidVersions": {
-        "min": "4.4",
-        "max": "All",
-        "notes": "Requires multi-user support, which began in Android 4.4 (KitKat)"
-      }
-    },
-    {
-      "id": 8,
-      "title": "Check Battery Stats",
-      "description": "Shows detailed information about the device's battery status and usage.",
-      "category": "deviceinfo",
-      "multiVersion": true,
-      "versions": [
-        {
-          "range": "4.0 - 7.0",
-          "windows": "adb shell dumpsys battery",
-          "mac": "adb shell dumpsys battery",
-          "notes": "Basic battery information"
-        },
-        {
-          "range": "8.0 - 9.0",
-          "windows": "adb shell dumpsys batterystats",
-          "mac": "adb shell dumpsys batterystats",
-          "notes": "Enhanced battery stats with usage by app introduced in Oreo"
-        },
-        {
-          "range": "10+",
-          "windows": "adb shell dumpsys batterystats --charged",
-          "mac": "adb shell dumpsys batterystats --charged",
-          "notes": "More detailed battery usage stats with additional parameters available"
-        }
-      ]
-    },
-    {
-      "id": 9,
-      "title": "Uninstall App",
-      "windows": "adb uninstall com.example.app",
-      "mac": "adb uninstall com.example.app",
-      "description": "Removes an app from the device. You need to specify the package name, not the app name.",
-      "category": "installation",
-      "androidVersions": {
-        "min": "All",
-        "max": "All",
-        "notes": "Core ADB command that works across all Android versions"
-      }
-    },
-    {
-      "id": 10,
-      "title": "Wireless Debugging Setup",
-      "description": "Sets up wireless debugging to connect to your device over WiFi instead of USB.",
-      "category": "connection",
-      "multiVersion": true,
-      "versions": [
-        {
-          "range": "4.0 - 10.0",
-          "windows": "adb tcpip 5555 && adb shell ip addr show wlan0 | findstr \"inet\" && adb connect [device_ip]:5555",
-          "mac": "adb tcpip 5555 && adb shell ip addr show wlan0 | grep inet && adb connect [device_ip]:5555",
-          "notes": "Traditional method requiring initial USB connection"
-        },
-        {
-          "range": "11+",
-          "windows": "adb pair [ip_address]:[pairing_port]",
-          "mac": "adb pair [ip_address]:[pairing_port]",
-          "notes": "Android 11+ supports secure pairing. Enable \"Wireless debugging\" in Developer options to get pairing code."
-        }
-      ]
-    },
-    {
-      "id": 11,
-      "title": "Backup Device",
-      "windows": "adb backup -apk -shared -all -f backup_file.ab",
-      "mac": "adb backup -apk -shared -all -f backup_file.ab",
-      "description": "Creates a full backup of the device. Not all devices support this feature, especially newer Android versions with work profiles.",
-      "category": "deviceinfo",
-      "androidVersions": {
-        "min": "4.0",
-        "max": "10.0",
-        "notes": "Functionality limited after Android 9, deprecated since Android 10. No longer reliable on newer devices."
-      }
-    },
-    {
-      "id": 12,
-      "title": "View Device Logs",
-      "windows": "adb logcat",
-      "mac": "adb logcat",
-      "description": "Shows real-time logs from the device. Useful for debugging crashes or unexpected behavior. Use Ctrl+C to stop.",
-      "category": "troubleshooting",
-      "androidVersions": {
-        "min": "All",
-        "max": "All",
-        "notes": "Core ADB command that works across all Android versions"
-      }
-    },
-    {
-      "id": 13,
-      "title": "Force Stop App",
-      "description": "Forces an app to stop running. Useful when an app is unresponsive or for testing app recovery.",
-      "category": "troubleshooting",
-      "multiVersion": true,
-      "versions": [
-        {
-          "range": "All",
-          "windows": "adb shell am force-stop com.example.app",
-          "mac": "adb shell am force-stop com.example.app",
-          "notes": "Basic force stop command"
-        },
-        {
-          "range": "9.0+",
-          "windows": "adb shell am kill com.example.app",
-          "mac": "adb shell am kill com.example.app",
-          "notes": "Alternative method that kills the process but may allow background services to restart"
-        }
-      ]
-    },
-    {
-      "id": 14,
-      "title": "Get Device Model",
-      "windows": "adb shell getprop ro.product.model",
-      "mac": "adb shell getprop ro.product.model",
-      "description": "Retrieves the model name of the connected device. Helpful for documentation or ensuring compatibility.",
-      "category": "deviceinfo",
-      "androidVersions": {
-        "min": "All",
-        "max": "All",
-        "notes": "Core property available on all Android versions"
-      }
-    },
-    {
-      "id": 15,
-      "title": "Get Android Version",
-      "windows": "adb shell getprop ro.build.version.release",
-      "mac": "adb shell getprop ro.build.version.release",
-      "description": "Displays the Android version (e.g., 13.0) running on the device.",
-      "category": "deviceinfo",
-      "androidVersions": {
-        "min": "All",
-        "max": "All",
-        "notes": "Core property available on all Android versions"
-      }
-    },
-    {
-      "id": 16,
-      "title": "Get Enterprise Info (Work Profile)",
-      "description": "Gets information about enterprise provisioning and work profile status.",
-      "category": "deviceinfo",
-      "multiVersion": true,
-      "versions": [
-        {
-          "range": "5.0 - 8.0",
-          "windows": "adb shell dumpsys device_policy",
-          "mac": "adb shell dumpsys device_policy",
-          "notes": "Basic device policy information for Android Lollipop through Oreo"
-        },
-        {
-          "range": "9.0 - 11.0",
-          "windows": "adb shell dumpsys device_policy | findstr \"Profile Owner\"",
-          "mac": "adb shell dumpsys device_policy | grep \"Profile Owner\"",
-          "notes": "Filtered output to check for profile owner and work profile"
-        },
-        {
-          "range": "12+",
-          "windows": "adb shell dumpsys device_policy | findstr -i \"owner|profile\"",
-          "mac": "adb shell dumpsys device_policy | grep -i \"owner\\|profile\"",
-          "notes": "More detailed grep to handle format changes in Android 12+"
-        }
-      ]
-    },
-    {
-      "id": 17,
-      "title": "Get Package List",
-      "windows": "adb shell pm list packages",
-      "mac": "adb shell pm list packages",
-      "description": "Lists all installed packages on the device. Add '-s' for system apps only or '-3' for user-installed apps only.",
-      "category": "deviceinfo",
-      "androidVersions": {
-        "min": "All",
-        "max": "All",
-        "notes": "Core package manager command available on all Android versions"
-      }
-    },
-    {
-      "id": 18,
-      "title": "Start Activity Manager",
-      "windows": "adb shell am start -n com.package.name/com.package.name.ActivityName",
-      "mac": "adb shell am start -n com.package.name/com.package.name.ActivityName",
-      "description": "Launches a specific activity within an app. Useful for debugging or automating specific screens.",
-      "category": "troubleshooting",
-      "androidVersions": {
-        "min": "All",
-        "max": "All",
-        "notes": "Core activity manager command available on all Android versions"
-      }
-    },
-    {
-      "id": 19,
-      "title": "Reboot Device",
-      "windows": "adb reboot",
-      "mac": "adb reboot",
-      "description": "Reboots the connected device. Useful when troubleshooting or after making system-level changes.",
-      "category": "troubleshooting",
-      "androidVersions": {
-        "min": "All",
-        "max": "All",
-        "notes": "Core ADB command that works across all Android versions"
-      }
-    },
-    {
-      "id": 20,
-      "title": "Record Screen",
-      "windows": "adb shell screenrecord /sdcard/recording.mp4",
-      "mac": "adb shell screenrecord /sdcard/recording.mp4",
-      "description": "Records the device screen as an MP4 video. Press Ctrl+C to stop recording, then use 'adb pull' to retrieve the file.",
-      "category": "troubleshooting",
-      "androidVersions": {
-        "min": "4.4",
-        "max": "All",
-        "notes": "Screen recording was introduced in Android 4.4 (KitKat)"
-      }
-    },
-    {
-      "id": 21,
-      "title": "Copy Files to Device",
-      "windows": "adb push local_file.txt /sdcard/",
-      "mac": "adb push local_file.txt /sdcard/",
-      "description": "Transfers a file from your computer to the device storage. Useful for testing or deploying configuration files.",
-      "category": "troubleshooting",
-      "androidVersions": {
-        "min": "All",
-        "max": "All",
-        "notes": "Core ADB command that works across all Android versions"
-      }
-    },
-    {
-      "id": 22,
-      "title": "Copy Files from Device",
-      "windows": "adb pull /sdcard/file.txt local_folder/",
-      "mac": "adb pull /sdcard/file.txt local_folder/",
-      "description": "Retrieves a file from the device to your computer. Essential for collecting logs or other generated files.",
-      "category": "troubleshooting",
-      "androidVersions": {
-        "min": "All",
-        "max": "All",
-        "notes": "Core ADB command that works across all Android versions"
-      }
-    },
-    {
-      "id": 23,
-      "title": "Check WiFi Status",
-      "windows": "adb shell dumpsys wifi",
-      "mac": "adb shell dumpsys wifi",
-      "description": "Provides comprehensive information about the device's WiFi connection, useful for network troubleshooting.",
-      "category": "deviceinfo",
-      "androidVersions": {
-        "min": "All",
-        "max": "All",
-        "notes": "Core dumpsys command available on all Android versions"
-      }
-    },
-    {
-      "id": 24,
-      "title": "Get Device Serial Number",
-      "windows": "adb shell getprop ro.serialno",
-      "mac": "adb shell getprop ro.serialno",
-      "description": "Retrieves the device's serial number. Important for inventory management or when managing multiple devices.",
-      "category": "deviceinfo",
-      "androidVersions": {
-        "min": "All",
-        "max": "All",
-        "notes": "Core property available on all Android versions"
-      }
-    },
-    {
-      "id": 25,
-      "title": "Send Text Input",
-      "windows": "adb shell input text \"your_text_here\"",
-      "mac": "adb shell input text \"your_text_here\"",
-      "description": "Types the specified text on the device. Helpful for automating text entry during testing or setup.",
-      "category": "troubleshooting",
-      "androidVersions": {
-        "min": "4.1",
-        "max": "All",
-        "notes": "Input subsystem commands became reliable from Android 4.1 (Jelly Bean)"
-      }
-    },
-    {
-      "id": 26,
-      "title": "Check Device Uptime",
-      "windows": "adb shell uptime",
-      "mac": "adb shell uptime",
-      "description": "Shows how long the device has been running since the last boot. Useful for stability testing or verifying recent reboots.",
-      "category": "deviceinfo",
-      "androidVersions": {
-        "min": "All",
-        "max": "All",
-        "notes": "Core Linux/Unix command available on all Android versions"
-      }
-    },
-    {
-      "id": 27,
-      "title": "Clear App Data",
-      "windows": "adb shell pm clear com.example.app",
-      "mac": "adb shell pm clear com.example.app",
-      "description": "Clears all data for a specified app (similar to clearing data in Settings). Helpful for troubleshooting app issues.",
-      "category": "troubleshooting",
-      "androidVersions": {
-        "min": "All",
-        "max": "All",
-        "notes": "Core package manager command available on all Android versions"
-      }
-    },
-    {
-      "id": 28,
-      "title": "Get Device IP Address",
-      "description": "Displays the IP address of the device's WiFi connection. Useful before setting up wireless debugging.",
-      "category": "connection",
-      "multiVersion": true,
-      "versions": [
-        {
-          "range": "4.0 - 4.4",
-          "windows": "adb shell netcfg | findstr wlan",
-          "mac": "adb shell netcfg | grep wlan",
-          "notes": "Legacy command for Android KitKat and earlier"
-        },
-        {
-          "range": "5.0 - 6.0",
-          "windows": "adb shell ifconfig wlan0",
-          "mac": "adb shell ifconfig wlan0",
-          "notes": "Traditional Unix ifconfig command works on Lollipop and Marshmallow"
-        },
-        {
-          "range": "7.0+",
-          "windows": "adb shell ip addr show wlan0",
-          "mac": "adb shell ip addr show wlan0",
-          "notes": "Modern format available since Android Nougat"
-        }
-      ]
-    },
-    {
-      "id": 29,
-      "title": "Grant App Permissions",
-      "windows": "adb shell pm grant com.example.app android.permission.PERMISSION_NAME",
-      "mac": "adb shell pm grant com.example.app android.permission.PERMISSION_NAME",
-      "description": "Grants a specific permission to an app. Useful for automating permission grants during testing.",
-      "category": "troubleshooting",
-      "androidVersions": {
-        "min": "6.0",
-        "max": "All",
-        "notes": "Runtime permissions were introduced in Android 6.0 (Marshmallow)"
-      }
-    },
-    {
-      "id": 30,
-      "title": "Revoke App Permissions",
-      "windows": "adb shell pm revoke com.example.app android.permission.PERMISSION_NAME",
-      "mac": "adb shell pm revoke com.example.app android.permission.PERMISSION_NAME",
-      "description": "Revokes a specific permission from an app. Useful for testing permission denial scenarios.",
-      "category": "troubleshooting",
-      "androidVersions": {
-        "min": "6.0",
-        "max": "All",
-        "notes": "Runtime permissions were introduced in Android 6.0 (Marshmallow)"
       }
     }
-  ]
+  },
+  {
+    "id": 2,
+    "title": "Connect to Device over WiFi",
+    "windows": "adb connect ip_address:port",
+    "mac": "adb connect ip_address:port",
+    "description": "Connects to a device over WiFi instead of USB. You'll need to know the device's IP address, and it must be on the same network as your computer.",
+    "category": "connection",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Requires developer options enabled and ADB debugging turned on"
+    },
+    "verification": {
+      "verified": true,
+      "lastTested": "2025-11-10",
+      "testedVersions": {
+        "36": {
+          "status": "pass",
+          "date": "2025-11-10",
+          "output": "connected to 192.168.0.100:12345\n",
+          "error": null,
+          "notes": null
+        },
+        "35": {
+          "status": "pass",
+          "date": "2025-11-10",
+          "output": "bad port number 'port' in 'ip_address:port'\n",
+          "error": null,
+          "notes": null
+        },
+        "34": {
+          "status": "pass",
+          "date": "2025-11-10",
+          "output": "bad port number 'port' in 'ip_address:port'\n",
+          "error": null,
+          "notes": null
+        }
+      }
+    }
+  },
+  {
+    "id": 3,
+    "title": "Get Current Activity (Foreground App)",
+    "description": "Shows the current activity that's in the foreground. Useful for debugging or automation to determine what's currently visible on screen.",
+    "category": "deviceinfo",
+    "multiVersion": true,
+    "versions": [
+      {
+        "range": "12 - 13",
+        "windows": "adb shell dumpsys activity recents",
+        "mac": "adb shell \"dumpsys activity recents | grep 'Recent #0'\"",
+        "notes": "Android 12 introduced activity recents command for current activity",
+        "verification": {
+          "verified": false,
+          "lastTested": "",
+          "testedVersions": {
+            "31": {
+              "status": "pass",
+              "date": "2025-11-10",
+              "output": "  * Recent #0: Task{... type=home I=com.google.android.apps.nexuslauncher/.NexusLauncherActivity}\n",
+              "error": null,
+              "notes": null
+            },
+            "33": {
+              "status": "pass",
+              "date": "2025-11-10",
+              "output": "  * Recent #0: Task{... type=home I=com.google.android.apps.nexuslauncher/.NexusLauncherActivity}\n",
+              "error": null,
+              "notes": null
+            }
+          }
+        }
+      },
+      {
+        "range": "14",
+        "windows": "adb shell dumpsys activity activities | grep mResumedActivity",
+        "mac": "adb shell dumpsys activity activities | grep mResumedActivity",
+        "notes": "Android 14 changed format, use mResumedActivity for current foreground activity",
+        "verification": {
+          "verified": true,
+          "lastTested": "2025-11-10",
+          "testedVersions": {
+            "34": {
+              "status": "pass",
+              "date": "2025-11-10",
+              "output": "  mResumedActivity: ActivityRecord{... com.google.android.apps.nexuslauncher/.NexusLauncherActivity ...}\n",
+              "error": null,
+              "notes": null
+            }
+          }
+        }
+      },
+      {
+        "range": "15+",
+        "windows": "adb shell dumpsys activity recents",
+        "mac": "adb shell \"dumpsys activity recents | grep 'Recent #0'\"",
+        "notes": "Android 15+ returns to using activity recents format",
+        "verification": {
+          "verified": true,
+          "lastTested": "2025-11-10",
+          "testedVersions": {
+            "35": {
+              "status": "pass",
+              "date": "2025-11-10",
+              "output": "  * Recent #0: Task{63b4f28 #7 type=home I=com.google.android.apps.nexuslauncher/.NexusLauncherActivity}\n",
+              "error": null,
+              "notes": null
+            },
+            "36": {
+              "status": "pass",
+              "date": "2025-11-10",
+              "output": "  * Recent #0: Task{6d5d626 #2 type=home I=com.google.android.apps.nexuslauncher/.NexusLauncherActivity}\n",
+              "error": null,
+              "notes": null
+            }
+          }
+        }
+      }
+    ],
+    "verification": {
+      "verified": true,
+      "lastTested": "2025-11-10",
+      "overallStatus": "partial"
+    }
+  },
+  {
+    "id": 4,
+    "title": "Check Package Info",
+    "description": "Gets detailed information about a specific package (app), including version, install time, and permissions.",
+    "category": "deviceinfo",
+    "multiVersion": true,
+    "versions": [
+      {
+        "range": "12+",
+        "windows": "adb shell pm dump com.example.app",
+        "mac": "adb shell pm dump com.android.settings",
+        "notes": "Use package manager commands to get cleaner output",
+        "verification": {
+          "verified": false,
+          "lastTested": null,
+          "testedVersions": {}
+        }
+      }
+    ],
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "overallStatus": "untested"
+    }
+  },
+  {
+    "id": 5,
+    "title": "Get Device Screenshot",
+    "description": "Captures a screenshot of the device screen and saves it to your computer.",
+    "category": "troubleshooting",
+    "multiVersion": false,
+    "windows": "adb exec-out screencap -p > screenshot.png",
+    "mac": "adb exec-out screencap -p > screenshot.png",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Efficient single-command process using exec-out"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 6,
+    "title": "Install APK",
+    "windows": "adb install path\\to\\app.apk",
+    "mac": "adb install path/to/app.apk",
+    "description": "Installs an APK file onto the connected device. Add the '-r' flag to replace an existing application.",
+    "category": "installation",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Core ADB command that works across all Android versions"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 7,
+    "title": "Install APK to Specific User",
+    "windows": "adb install --user user_id path\\to\\app.apk",
+    "mac": "adb install --user user_id path/to/app.apk",
+    "description": "Installs an APK for a specific user on a multi-user device. Particularly useful in enterprise environments with work profiles.",
+    "category": "installation",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Requires multi-user support for installing to specific users"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 8,
+    "title": "Check Battery Stats",
+    "description": "Shows detailed information about the device's battery status and usage.",
+    "category": "deviceinfo",
+    "multiVersion": false,
+    "windows": "adb shell dumpsys batterystats --charged",
+    "mac": "adb shell dumpsys batterystats --charged",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Detailed battery usage stats with additional parameters"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 9,
+    "title": "Uninstall App",
+    "windows": "adb uninstall com.example.app",
+    "mac": "adb uninstall com.example.app",
+    "description": "Removes an app from the device. You need to specify the package name, not the app name.",
+    "category": "installation",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Core ADB command that works across all Android versions"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 10,
+    "title": "Wireless Debugging Setup",
+    "description": "Sets up wireless debugging to connect to your device over WiFi instead of USB.",
+    "category": "connection",
+    "multiVersion": false,
+    "windows": "adb pair [ip_address]:[pairing_port]",
+    "mac": "adb pair [ip_address]:[pairing_port]",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Android 12+ supports secure pairing. Enable \"Wireless debugging\" in Developer options to get pairing code."
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 12,
+    "title": "View Device Logs",
+    "windows": "adb logcat",
+    "mac": "adb logcat",
+    "description": "Shows real-time logs from the device. Useful for debugging crashes or unexpected behavior. Use Ctrl+C to stop.",
+    "category": "troubleshooting",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Core ADB command that works across all Android versions"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 13,
+    "title": "Force Stop App",
+    "description": "Forces an app to stop running. Useful when an app is unresponsive or for testing app recovery.",
+    "category": "troubleshooting",
+    "multiVersion": true,
+    "versions": [
+      {
+        "range": "All",
+        "windows": "adb shell am force-stop com.example.app",
+        "mac": "adb shell am force-stop com.example.app",
+        "notes": "Basic force stop command",
+        "verification": {
+          "verified": false,
+          "lastTested": null,
+          "testedVersions": {}
+        }
+      },
+      {
+        "range": "9.0+",
+        "windows": "adb shell am kill com.example.app",
+        "mac": "adb shell am kill com.example.app",
+        "notes": "Alternative method that kills the process but may allow background services to restart",
+        "verification": {
+          "verified": false,
+          "lastTested": null,
+          "testedVersions": {}
+        }
+      }
+    ],
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "overallStatus": "untested"
+    }
+  },
+  {
+    "id": 14,
+    "title": "Get Device Model",
+    "windows": "adb shell getprop ro.product.model",
+    "mac": "adb shell getprop ro.product.model",
+    "description": "Retrieves the model name of the connected device. Helpful for documentation or ensuring compatibility.",
+    "category": "deviceinfo",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Core property available on all Android versions"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 15,
+    "title": "Get Android Version",
+    "windows": "adb shell getprop ro.build.version.release",
+    "mac": "adb shell getprop ro.build.version.release",
+    "description": "Displays the Android version (e.g., 13.0) running on the device.",
+    "category": "deviceinfo",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Core property available on all Android versions"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 16,
+    "title": "Get Enterprise Info (Work Profile)",
+    "description": "Gets information about enterprise provisioning and work profile status.",
+    "category": "deviceinfo",
+    "multiVersion": false,
+    "windows": "adb shell dumpsys device_policy | findstr -i \"owner|profile\"",
+    "mac": "adb shell dumpsys device_policy | grep -i \"owner\\|profile\"",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Detailed grep to check for device owner and work profile"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 17,
+    "title": "Get Package List",
+    "windows": "adb shell pm list packages",
+    "mac": "adb shell pm list packages",
+    "description": "Lists all installed packages on the device. Add '-s' for system apps only or '-3' for user-installed apps only.",
+    "category": "deviceinfo",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Core package manager command available on all Android versions"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 18,
+    "title": "Start Activity Manager",
+    "windows": "adb shell am start -n com.package.name/com.package.name.ActivityName",
+    "mac": "adb shell am start -n com.package.name/com.package.name.ActivityName",
+    "description": "Launches a specific activity within an app. Useful for debugging or automating specific screens.",
+    "category": "troubleshooting",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Core activity manager command available on all Android versions"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 19,
+    "title": "Reboot Device",
+    "windows": "adb reboot",
+    "mac": "adb reboot",
+    "description": "Reboots the connected device. Useful when troubleshooting or after making system-level changes.",
+    "category": "troubleshooting",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Core ADB command that works across all Android versions"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 20,
+    "title": "Record Screen",
+    "windows": "adb shell screenrecord /sdcard/recording.mp4",
+    "mac": "adb shell screenrecord /sdcard/recording.mp4",
+    "description": "Records the device screen as an MP4 video. Press Ctrl+C to stop recording, then use 'adb pull' to retrieve the file.",
+    "category": "troubleshooting",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Record device screen as an MP4 video"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 21,
+    "title": "Copy Files to Device",
+    "windows": "adb push local_file.txt /sdcard/",
+    "mac": "adb push local_file.txt /sdcard/",
+    "description": "Transfers a file from your computer to the device storage. Useful for testing or deploying configuration files.",
+    "category": "troubleshooting",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Core ADB command that works across all Android versions"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 22,
+    "title": "Copy Files from Device",
+    "windows": "adb pull /sdcard/file.txt local_folder/",
+    "mac": "adb pull /sdcard/file.txt local_folder/",
+    "description": "Retrieves a file from the device to your computer. Essential for collecting logs or other generated files.",
+    "category": "troubleshooting",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Core ADB command that works across all Android versions"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 23,
+    "title": "Check WiFi Status",
+    "windows": "adb shell dumpsys wifi",
+    "mac": "adb shell dumpsys wifi",
+    "description": "Provides comprehensive information about the device's WiFi connection, useful for network troubleshooting.",
+    "category": "deviceinfo",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Core dumpsys command available on all Android versions"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 24,
+    "title": "Get Device Serial Number",
+    "windows": "adb shell getprop ro.serialno",
+    "mac": "adb shell getprop ro.serialno",
+    "description": "Retrieves the device's serial number. Important for inventory management or when managing multiple devices.",
+    "category": "deviceinfo",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Core property available on all Android versions"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 25,
+    "title": "Send Text Input",
+    "windows": "adb shell input text \"your_text_here\"",
+    "mac": "adb shell input text \"your_text_here\"",
+    "description": "Types the specified text on the device. Helpful for automating text entry during testing or setup.",
+    "category": "troubleshooting",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Types the specified text on the device"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 26,
+    "title": "Check Device Uptime",
+    "windows": "adb shell uptime",
+    "mac": "adb shell uptime",
+    "description": "Shows how long the device has been running since the last boot. Useful for stability testing or verifying recent reboots.",
+    "category": "deviceinfo",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Core Linux/Unix command available on all Android versions"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 27,
+    "title": "Clear App Data",
+    "windows": "adb shell pm clear com.example.app",
+    "mac": "adb shell pm clear com.example.app",
+    "description": "Clears all data for a specified app (similar to clearing data in Settings). Helpful for troubleshooting app issues.",
+    "category": "troubleshooting",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Core package manager command available on all Android versions"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 28,
+    "title": "Get Device IP Address",
+    "description": "Displays the IP address of the device's WiFi connection. Useful before setting up wireless debugging.",
+    "category": "connection",
+    "multiVersion": false,
+    "windows": "adb shell ip addr show wlan0",
+    "mac": "adb shell ip addr show wlan0",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Shows IP address of device's WiFi connection"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 29,
+    "title": "Grant App Permissions",
+    "windows": "adb shell pm grant com.example.app android.permission.PERMISSION_NAME",
+    "mac": "adb shell pm grant com.example.app android.permission.PERMISSION_NAME",
+    "description": "Grants a specific permission to an app. Useful for automating permission grants during testing.",
+    "category": "troubleshooting",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Grant specific runtime permissions to an app"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  },
+  {
+    "id": 30,
+    "title": "Revoke App Permissions",
+    "windows": "adb shell pm revoke com.example.app android.permission.PERMISSION_NAME",
+    "mac": "adb shell pm revoke com.example.app android.permission.PERMISSION_NAME",
+    "description": "Revokes a specific permission from an app. Useful for testing permission denial scenarios.",
+    "category": "troubleshooting",
+    "androidVersions": {
+      "min": "12",
+      "max": "All",
+      "notes": "Grant specific runtime permissions to an app"
+    },
+    "verification": {
+      "verified": false,
+      "lastTested": null,
+      "testedVersions": {}
+    }
+  }
+]

--- a/tools/adb-cmd/index.html
+++ b/tools/adb-cmd/index.html
@@ -28,8 +28,13 @@
   
   <!-- Custom styles -->
   <style>
+    .command-card {
+      position: relative;
+      overflow: visible;
+    }
     .command-card:hover {
       box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+      z-index: 10;
     }
     .copy-icon:hover {
       color: #3B82F6;
@@ -108,6 +113,166 @@
       justify-content: center;
       padding: 2rem;
     }
+
+    /* Verification Badge Styles */
+    .verification-badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.25rem 0.75rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      margin-left: 0.5rem;
+      cursor: help;
+      position: relative;
+      transition: all 0.2s;
+    }
+
+    .verification-badge:hover {
+      transform: scale(1.05);
+    }
+
+    .verification-badge.verified {
+      background-color: #10b981;
+      color: white;
+    }
+
+    .verification-badge.unverified {
+      background-color: #6b7280;
+      color: white;
+    }
+
+    .verification-badge i {
+      margin-right: 0.25rem;
+    }
+
+    /* Verification Tooltip */
+    .verification-tooltip {
+      position: fixed;
+      padding: 0.75rem;
+      background-color: #1f2937;
+      color: white;
+      border-radius: 0.375rem;
+      font-size: 0.75rem;
+      white-space: normal;
+      opacity: 0;
+      visibility: hidden;
+      pointer-events: none;
+      transition: opacity 0.2s ease-out, visibility 0.2s ease-out;
+      z-index: 9999;
+      min-width: 200px;
+      max-width: 300px;
+      box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.3), 0 8px 10px -5px rgba(0, 0, 0, 0.2);
+    }
+
+    .verification-tooltip::after {
+      content: '';
+      position: absolute;
+      bottom: -6px;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 6px solid transparent;
+      border-top-color: #1f2937;
+    }
+
+    .verification-tooltip.below::after {
+      bottom: auto;
+      top: -6px;
+      border-top-color: transparent;
+      border-bottom-color: #1f2937;
+    }
+
+    .verification-tooltip.show {
+      opacity: 1;
+      visibility: visible;
+    }
+
+    .verification-tooltip-content {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    .tooltip-version {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.125rem 0;
+    }
+
+    .tooltip-version i {
+      font-size: 0.625rem;
+      width: 12px;
+      flex-shrink: 0;
+    }
+
+    .tooltip-version span {
+      white-space: nowrap;
+    }
+
+    .api-level-badges {
+      display: none;
+    }
+
+    .api-level-badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.125rem 0.5rem;
+      border-radius: 0.25rem;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      border: 1px solid;
+    }
+
+    .api-level-badge.passed {
+      background-color: #d1fae5;
+      color: #065f46;
+      border-color: #10b981;
+    }
+
+    .api-level-badge.failed {
+      background-color: #fee2e2;
+      color: #991b1b;
+      border-color: #ef4444;
+    }
+
+    .verification-info {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-top: 0.5rem;
+      padding: 0.5rem;
+      background-color: #f9fafb;
+      border-radius: 0.375rem;
+      font-size: 0.75rem;
+      color: #6b7280;
+    }
+
+    .verification-info i {
+      color: #10b981;
+    }
+
+    /* Output display styles */
+    pre {
+      margin: 0;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+    }
+
+    pre code {
+      display: block;
+      font-family: 'Courier New', Courier, monospace;
+      font-size: 0.75rem;
+      line-height: 1.4;
+    }
+
+    .bg-gray-900 {
+      background-color: #1a202c;
+    }
+
+    .text-gray-100 {
+      color: #f7fafc;
+    }
   </style>
 </head>
 <body class="bg-gray-100 min-h-screen">
@@ -135,7 +300,7 @@
         and those troubleshooting Android devices in an enterprise environment.
       </p>
       
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6 mb-6">
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-6 mb-6">
         <div class="bg-blue-50 border-l-4 border-blue-500 p-4">
           <div class="flex">
             <div class="flex-shrink-0">
@@ -195,6 +360,95 @@
                   <span>Limited version compatibility</span>
                 </div>
               </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="bg-purple-50 border-l-4 border-purple-500 p-4">
+          <div class="flex">
+            <div class="flex-shrink-0">
+              <i class="fas fa-shield-alt text-purple-500"></i>
+            </div>
+            <div class="ml-3">
+              <h3 class="text-sm font-medium text-purple-800">Verification Status</h3>
+              <div class="mt-2 text-sm text-purple-700">
+                <div class="flex items-center mb-1">
+                  <span class="verification-badge verified" style="font-size: 0.7rem; padding: 0.125rem 0.5rem;">
+                    <i class="fas fa-check-circle"></i>
+                    Verified
+                  </span>
+                  <span class="ml-2">Tested & working</span>
+                </div>
+                <div class="flex items-center mb-2">
+                  <span class="verification-badge unverified" style="font-size: 0.7rem; padding: 0.125rem 0.5rem;">
+                    <i class="fas fa-question-circle"></i>
+                    Unverified
+                  </span>
+                  <span class="ml-2">Not yet tested</span>
+                </div>
+                <div class="mt-2 pt-2 border-t border-purple-200">
+                  <div class="text-xs font-semibold mb-1">Verified API Levels (Android 12+):</div>
+                  <div class="text-xs text-purple-600 space-y-0.5">
+                    <div>API 36 - Android 16</div>
+                    <div>API 35 - Android 15</div>
+                    <div>API 34 - Android 14</div>
+                    <div>API 33 - Android 13</div>
+                    <div>API 32 - Android 12L</div>
+                    <div>API 31 - Android 12</div>
+                  </div>
+                </div>
+                <div class="mt-2 pt-2 border-t border-purple-200">
+                  <div class="text-xs font-semibold mb-1">Example Badges:</div>
+                  <div class="flex gap-1">
+                    <span class="api-level-badge passed" style="font-size: 0.625rem;">
+                      <i class="fas fa-check mr-1" style="font-size: 0.5rem;"></i>
+                      API 36
+                    </span>
+                    <span class="api-level-badge failed" style="font-size: 0.625rem;">
+                      <i class="fas fa-times mr-1" style="font-size: 0.5rem;"></i>
+                      API 35
+                    </span>
+                  </div>
+                </div>
+                <div class="bg-purple-100 border border-purple-300 rounded p-2 mt-3 text-xs">
+                  <i class="fas fa-info-circle mr-1"></i>
+                  <strong>Note:</strong> Only Android 12 and higher versions are being verified going forward.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="bg-blue-50 border-l-4 border-blue-500 p-4 mt-4">
+        <div class="flex">
+          <div class="flex-shrink-0">
+            <i class="fas fa-github text-blue-500"></i>
+          </div>
+          <div class="ml-3">
+            <h3 class="text-sm font-medium text-blue-800">Contribute to ADB Commands</h3>
+            <p class="text-sm text-blue-700 mt-1">
+              Found an issue with a command or want to suggest a new one? We welcome contributions from the community!
+            </p>
+            <div class="mt-3 flex flex-wrap gap-3">
+              <a href="https://github.com/mattintech/mattintech.github.io/issues/new?template=adb_cmd_bug_report.md&title=%5BADB%20CMD%20BUG%5D%20"
+                 target="_blank"
+                 class="inline-flex items-center px-3 py-1 border border-blue-500 text-blue-700 bg-white rounded-md hover:bg-blue-100 transition text-xs">
+                <i class="fas fa-bug mr-2"></i>
+                Report Command Issue
+              </a>
+              <a href="https://github.com/mattintech/mattintech.github.io/issues/new?template=adb_cmd_new_command.md&title=%5BNEW%20CMD%5D%20"
+                 target="_blank"
+                 class="inline-flex items-center px-3 py-1 border border-blue-500 text-blue-700 bg-white rounded-md hover:bg-blue-100 transition text-xs">
+                <i class="fas fa-plus-circle mr-2"></i>
+                Suggest New Command
+              </a>
+              <a href="https://github.com/mattintech/mattintech.github.io/issues"
+                 target="_blank"
+                 class="inline-flex items-center px-3 py-1 border border-gray-400 text-gray-700 bg-white rounded-md hover:bg-gray-100 transition text-xs">
+                <i class="fas fa-list mr-2"></i>
+                View All Issues
+              </a>
             </div>
           </div>
         </div>

--- a/tools/adb-cmd/utils/README.md
+++ b/tools/adb-cmd/utils/README.md
@@ -1,0 +1,237 @@
+# ADB Command Verification Tools
+
+Tools for testing, verifying, and adding ADB commands to the command database.
+
+## Tools Available
+
+1. **manual_verify.py** - Test and verify existing commands
+2. **add_command.py** - Add new commands with required verification
+
+## Quick Start
+
+### Prerequisites
+
+1. **Install Android SDK tools**:
+   ```bash
+   # macOS
+   brew install android-platform-tools
+
+   # Verify installation
+   adb version
+   ```
+
+2. **Create test AVDs** (one-time setup):
+   ```bash
+   # For API 36 (Android 16)
+   sdkmanager "system-images;android-36;google_apis;arm64-v8a"
+   avdmanager create avd -n test_android_36 -k "system-images;android-36;google_apis;arm64-v8a"
+
+   # For API 35 (Android 15)
+   sdkmanager "system-images;android-35;google_apis;arm64-v8a"
+   avdmanager create avd -n test_android_35 -k "system-images;android-35;google_apis;arm64-v8a"
+
+   # For API 34 (Android 14)
+   sdkmanager "system-images;android-34;google_apis;arm64-v8a"
+   avdmanager create avd -n test_android_34 -k "system-images;android-34;google_apis;arm64-v8a"
+
+   # For API 33 (Android 13)
+   sdkmanager "system-images;android-33;google_apis;arm64-v8a"
+   avdmanager create avd -n test_android_33 -k "system-images;android-33;google_apis;arm64-v8a"
+
+   # For API 31 (Android 12)
+   sdkmanager "system-images;android-31;google_apis;arm64-v8a"
+   avdmanager create avd -n test_android_31 -k "system-images;android-31;google_apis;arm64-v8a"
+   ```
+
+## Usage
+
+### Basic Testing
+
+Test all unverified commands on API 36:
+```bash
+python utils/manual_verify.py --api 36
+```
+
+### Test Specific Category
+
+Test only connection-related commands:
+```bash
+python utils/manual_verify.py --api 36 --category connection
+```
+
+Categories available:
+- `connection` - Device connection and wireless debugging
+- `installation` - APK installation and package management
+- `deviceinfo` - Device information and properties
+- `troubleshooting` - Debugging and troubleshooting commands
+
+### Test ALL Commands
+
+Test all commands, even if already verified:
+```bash
+python utils/manual_verify.py --api 36 --all
+```
+
+### Resume Testing
+
+If you stopped at command 15, resume from there:
+```bash
+python utils/manual_verify.py --api 36 --start-from 15
+```
+
+## Testing Workflow
+
+1. **Script starts emulator** automatically
+2. **Command executes** on the emulator
+3. **You see the output** (stdout, stderr, return code)
+4. **You verify** the result:
+   - `[p]` Pass - Command worked as expected
+   - `[f]` Fail - Command failed or unexpected output
+   - `[s]` Skip - Skip this command
+   - `[r]` Retry - Run command again
+   - `[o]` Paste Output - Manually provide expected output
+   - `[q]` Quit - Save and exit
+
+5. **Progress is saved** after each command (with your permission)
+
+## Features
+
+### Automatic Backups
+- Creates timestamped backups in `data/backups/` before modifications
+- Disable with `--no-backup` flag
+
+### Smart Testing
+- By default, only tests unverified commands
+- Re-tests previously failed commands
+- Skips commands already passing for the API level
+
+### Multi-Version Support
+- Automatically selects correct command variant for Android version
+- Tests appropriate syntax for each API level
+- Updates verification per version
+
+### Session Tracking
+- Shows progress and statistics
+- Allows saving after each command
+- Resume capability for long sessions
+
+## Output Structure
+
+Verification results are saved in `commands.json`:
+
+```json
+{
+  "id": 1,
+  "title": "List Connected Devices",
+  "verification": {
+    "verified": true,
+    "lastTested": "2025-11-10",
+    "testedVersions": {
+      "36": {
+        "status": "pass",
+        "date": "2025-11-10",
+        "output": "List of devices attached\nemulator-5554\tdevice",
+        "notes": null
+      }
+    }
+  }
+}
+```
+
+## Tips
+
+1. **Start with latest Android** (API 36) - most commands will work there
+2. **Test older versions** only for commands that might vary
+3. **Use categories** to test related commands together
+4. **Save frequently** - you can resume anytime
+5. **Paste output** option is useful for commands with dynamic output
+
+## Troubleshooting
+
+### Emulator won't start
+```bash
+# Check if AVD exists
+emulator -list-avds
+
+# Start manually to see errors
+emulator -avd test_android_36
+```
+
+### ADB not found
+```bash
+# Add to PATH
+export PATH=$PATH:~/Android/sdk/platform-tools
+```
+
+### Permission errors
+```bash
+# Make script executable
+chmod +x utils/manual_verify.py
+```
+
+## Adding New Commands
+
+Use `add_command.py` to add new ADB commands with mandatory verification:
+
+### Basic Usage
+
+```bash
+python utils/add_command.py
+```
+
+### Process
+
+1. **Enter Command Details**
+   - Title and description
+   - Category (connection, installation, deviceinfo, troubleshooting)
+   - Command syntax for Mac/Linux and Windows
+   - Android version compatibility
+
+2. **Multi-Version Support**
+   - Script asks if command varies by Android version
+   - Add different syntax for different Android ranges
+   - Each version can be tested separately
+
+3. **Mandatory Testing**
+   - Connect a device or start an emulator
+   - Script automatically tests the command
+   - You verify if output is correct
+   - Command is only added if test passes
+
+4. **Automatic Updates**
+   - commands.json is backed up
+   - New command added with verification status
+   - Ready for web display with verification badge
+
+### Example Session
+
+```bash
+$ python utils/add_command.py
+
+=== Basic Command Information ===
+Command title: Get Build Fingerprint
+Description: Shows the unique build identifier
+Category: deviceinfo
+
+=== Command Syntax ===
+Mac/Linux command: adb shell getprop ro.build.fingerprint
+Is the Windows command different? [Y/n]: n
+
+=== Command Testing ===
+Testing command: adb shell getprop ro.build.fingerprint
+STDOUT: google/sdk_gphone64_arm64/emu64a:14/UE1A.230829.030/...
+
+Did the command work as expected? y
+✓ Command tested successfully!
+✓ Command added to commands.json
+```
+
+## API Level Reference
+
+| API Level | Android Version | Year |
+|-----------|----------------|------|
+| 36        | Android 16     | 2025 |
+| 35        | Android 15     | 2024 |
+| 34        | Android 14     | 2023 |
+| 33        | Android 13     | 2022 |
+| 31        | Android 12     | 2021 |

--- a/tools/adb-cmd/utils/add_command.py
+++ b/tools/adb-cmd/utils/add_command.py
@@ -1,0 +1,522 @@
+#!/usr/bin/env python3
+"""
+Add New ADB Command Tool
+Interactive tool for adding and verifying new ADB commands
+"""
+
+import json
+import sys
+import subprocess
+import platform
+from pathlib import Path
+from datetime import datetime
+from typing import Dict, List, Optional, Any
+import shutil
+
+# ANSI color codes
+class Colors:
+    CYAN = '\033[96m'
+    GREEN = '\033[92m'
+    YELLOW = '\033[93m'
+    RED = '\033[91m'
+    WHITE = '\033[97m'
+    BOLD = '\033[1m'
+    RESET = '\033[0m'
+
+class CommandAdder:
+    def __init__(self):
+        self.commands_file = Path(__file__).parent.parent / 'data' / 'commands.json'
+        self.backup_dir = self.commands_file.parent / 'backups'
+        self.commands = self.load_commands()
+        self.is_mac = platform.system() == 'Darwin'
+        self.new_command = {}
+        self.test_device = None
+
+    def load_commands(self) -> List[Dict]:
+        """Load existing commands"""
+        with open(self.commands_file, 'r') as f:
+            return json.load(f)
+
+    def save_commands(self):
+        """Save commands with backup"""
+        # Create backup
+        self.backup_dir.mkdir(exist_ok=True)
+        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+        backup_file = self.backup_dir / f'commands_{timestamp}.json'
+        shutil.copy2(self.commands_file, backup_file)
+        print(f"{Colors.GREEN}✓ Backup created: {backup_file.name}{Colors.RESET}")
+
+        # Save updated commands
+        with open(self.commands_file, 'w') as f:
+            json.dump(self.commands, f, indent=2)
+        print(f"{Colors.GREEN}✓ commands.json updated{Colors.RESET}")
+
+    def get_next_id(self) -> int:
+        """Get the next available command ID"""
+        if not self.commands:
+            return 1
+        return max(cmd['id'] for cmd in self.commands) + 1
+
+    def prompt_input(self, prompt: str, required: bool = True, default: str = None) -> str:
+        """Get input from user with optional default"""
+        if default:
+            prompt_text = f"{Colors.CYAN}{prompt} [{default}]: {Colors.RESET}"
+        else:
+            prompt_text = f"{Colors.CYAN}{prompt}: {Colors.RESET}"
+
+        while True:
+            value = input(prompt_text).strip()
+
+            if not value and default:
+                return default
+
+            if value or not required:
+                return value
+
+            print(f"{Colors.RED}This field is required!{Colors.RESET}")
+
+    def prompt_choice(self, prompt: str, choices: List[str], default: str = None) -> str:
+        """Get choice from user"""
+        print(f"\n{Colors.CYAN}{prompt}{Colors.RESET}")
+        for i, choice in enumerate(choices, 1):
+            if default and choice == default:
+                print(f"  [{i}] {choice} (default)")
+            else:
+                print(f"  [{i}] {choice}")
+
+        while True:
+            value = input(f"{Colors.CYAN}Enter choice (1-{len(choices)}): {Colors.RESET}").strip()
+
+            if not value and default:
+                return default
+
+            try:
+                idx = int(value) - 1
+                if 0 <= idx < len(choices):
+                    return choices[idx]
+            except ValueError:
+                # Check if they typed the choice directly
+                if value in choices:
+                    return value
+
+            print(f"{Colors.RED}Invalid choice!{Colors.RESET}")
+
+    def prompt_yes_no(self, prompt: str, default: bool = True) -> bool:
+        """Get yes/no answer"""
+        default_text = "Y/n" if default else "y/N"
+        while True:
+            value = input(f"{Colors.CYAN}{prompt} [{default_text}]: {Colors.RESET}").lower().strip()
+
+            if not value:
+                return default
+
+            if value in ['y', 'yes']:
+                return True
+            elif value in ['n', 'no']:
+                return False
+
+            print(f"{Colors.RED}Please enter yes or no{Colors.RESET}")
+
+    def get_basic_info(self):
+        """Get basic command information"""
+        print(f"\n{Colors.BOLD}{Colors.GREEN}=== Basic Command Information ==={Colors.RESET}")
+
+        self.new_command['id'] = self.get_next_id()
+        print(f"Command ID: {self.new_command['id']}")
+
+        self.new_command['title'] = self.prompt_input("Command title (e.g., 'Get Device Properties')")
+        self.new_command['description'] = self.prompt_input("Description (what does this command do?)")
+
+        # Category
+        categories = ['connection', 'installation', 'deviceinfo', 'troubleshooting']
+        self.new_command['category'] = self.prompt_choice("Category", categories)
+
+    def get_command_syntax(self):
+        """Get command syntax for different platforms"""
+        print(f"\n{Colors.BOLD}{Colors.GREEN}=== Command Syntax ==={Colors.RESET}")
+
+        # Check if multi-version command
+        is_multiversion = self.prompt_yes_no("Does this command have different syntax for different Android versions?", False)
+
+        if is_multiversion:
+            self.new_command['multiVersion'] = True
+            self.new_command['versions'] = []
+            self.get_multiversion_commands()
+        else:
+            # Single version command
+            self.get_single_version_command()
+
+    def get_single_version_command(self):
+        """Get command for single version"""
+        print(f"\n{Colors.CYAN}Enter the ADB command (including 'adb' prefix):{Colors.RESET}")
+
+        # Get Mac/Linux version
+        mac_cmd = self.prompt_input("Mac/Linux command")
+        self.new_command['mac'] = mac_cmd
+
+        # Check if Windows is different
+        if self.prompt_yes_no("Is the Windows command different?", False):
+            win_cmd = self.prompt_input("Windows command")
+            self.new_command['windows'] = win_cmd
+        else:
+            self.new_command['windows'] = mac_cmd
+
+        # Android version support
+        print(f"\n{Colors.CYAN}Android Version Support:{Colors.RESET}")
+        min_version = self.prompt_input("Minimum Android version (e.g., '4.0', '6.0', or 'All')", default="All")
+        max_version = self.prompt_input("Maximum Android version (e.g., '14.0', or 'All')", default="All")
+        notes = self.prompt_input("Notes about version compatibility", required=False)
+
+        self.new_command['androidVersions'] = {
+            'min': min_version,
+            'max': max_version,
+            'notes': notes if notes else None
+        }
+
+    def get_multiversion_commands(self):
+        """Get multiple versions of command"""
+        print(f"\n{Colors.YELLOW}Adding version-specific commands...{Colors.RESET}")
+        print("Add versions from oldest to newest Android version")
+
+        version_count = 1
+        while True:
+            print(f"\n{Colors.CYAN}Version {version_count}:{Colors.RESET}")
+
+            version = {}
+
+            # Get version range
+            version['range'] = self.prompt_input("Version range (e.g., '4.0 - 10.0', '11+', 'All')")
+
+            # Get commands
+            mac_cmd = self.prompt_input("Mac/Linux command")
+            version['mac'] = mac_cmd
+
+            if self.prompt_yes_no("Is the Windows command different?", False):
+                win_cmd = self.prompt_input("Windows command")
+                version['windows'] = win_cmd
+            else:
+                version['windows'] = mac_cmd
+
+            # Notes
+            notes = self.prompt_input("Notes about this version", required=False)
+            if notes:
+                version['notes'] = notes
+
+            # Initialize verification structure
+            version['verification'] = {
+                'verified': False,
+                'lastTested': None,
+                'testedVersions': {}
+            }
+
+            self.new_command['versions'].append(version)
+            version_count += 1
+
+            if not self.prompt_yes_no("Add another version?", False):
+                break
+
+        # Add overall verification for multi-version
+        self.new_command['verification'] = {
+            'verified': False,
+            'lastTested': None,
+            'overallStatus': 'untested'
+        }
+
+    def test_command(self) -> bool:
+        """Test the new command on a device"""
+        print(f"\n{Colors.BOLD}{Colors.GREEN}=== Command Testing ==={Colors.RESET}")
+        print(f"{Colors.YELLOW}The command must be tested on at least one Android version before adding.{Colors.RESET}")
+
+        # Check for connected devices
+        result = subprocess.run(['adb', 'devices'], capture_output=True, text=True)
+        lines = result.stdout.strip().split('\n')[1:]
+        devices = []
+
+        for line in lines:
+            if '\t' in line and 'device' in line:
+                device_serial = line.split('\t')[0]
+                devices.append(device_serial)
+
+        if not devices:
+            print(f"{Colors.RED}No devices connected!{Colors.RESET}")
+            print("Please connect a device or start an emulator:")
+            print("  emulator -avd test_android_36")
+            return False
+
+        # Select device if multiple
+        if len(devices) == 1:
+            self.test_device = devices[0]
+            print(f"Using device: {self.test_device}")
+        else:
+            print(f"\n{Colors.CYAN}Multiple devices found:{Colors.RESET}")
+            for i, device in enumerate(devices, 1):
+                print(f"  [{i}] {device}")
+            choice = int(self.prompt_input(f"Select device (1-{len(devices)})")) - 1
+            self.test_device = devices[choice]
+
+        # Get device API level
+        api_result = subprocess.run(
+            ['adb', '-s', self.test_device, 'shell', 'getprop', 'ro.build.version.sdk'],
+            capture_output=True,
+            text=True
+        )
+        api_level = api_result.stdout.strip()
+        print(f"Device API level: {api_level}")
+
+        # Get Android version
+        ver_result = subprocess.run(
+            ['adb', '-s', self.test_device, 'shell', 'getprop', 'ro.build.version.release'],
+            capture_output=True,
+            text=True
+        )
+        android_version = ver_result.stdout.strip()
+        print(f"Android version: {android_version}")
+
+        # Determine which command to test
+        if self.new_command.get('multiVersion'):
+            # Find appropriate version
+            test_version = None
+            for version in self.new_command['versions']:
+                print(f"  Checking version: {version['range']}")
+                # Simple check - you might want to expand this
+                if version['range'] == 'All' or '+' in version['range']:
+                    test_version = version
+                    break
+            if not test_version:
+                test_version = self.new_command['versions'][-1]  # Use latest
+
+            command = test_version['mac'] if self.is_mac else test_version['windows']
+            version_obj = test_version
+        else:
+            command = self.new_command['mac'] if self.is_mac else self.new_command['windows']
+            version_obj = None
+
+        # Test the command
+        print(f"\n{Colors.CYAN}Testing command: {Colors.WHITE}{command}{Colors.RESET}")
+
+        # Replace 'adb' with 'adb -s device_serial'
+        if command.startswith('adb '):
+            test_command = f"adb -s {self.test_device} {command[4:]}"
+        else:
+            test_command = command
+
+        print(f"Executing: {test_command}")
+        print(f"\n{Colors.YELLOW}{'='*70}{Colors.RESET}")
+
+        # Execute
+        result = subprocess.run(
+            test_command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        # Show results
+        if result.stdout:
+            print(f"{Colors.GREEN}STDOUT:{Colors.RESET}")
+            lines = result.stdout.split('\n')
+            if len(lines) > 20:
+                print('\n'.join(lines[:20]))
+                print(f"{Colors.YELLOW}... ({len(lines)-20} more lines){Colors.RESET}")
+            else:
+                print(result.stdout)
+
+        if result.stderr:
+            print(f"{Colors.RED}STDERR:{Colors.RESET}")
+            print(result.stderr)
+
+        print(f"\n{Colors.CYAN}Return code: {result.returncode}{Colors.RESET}")
+        print(f"{Colors.YELLOW}{'='*70}{Colors.RESET}")
+
+        # Get verification
+        print(f"\n{Colors.BOLD}Did the command work as expected?{Colors.RESET}")
+        print(f"  [{Colors.GREEN}y{Colors.RESET}] Yes - Command worked correctly")
+        print(f"  [{Colors.RED}n{Colors.RESET}] No - Command failed")
+        print(f"  [{Colors.CYAN}r{Colors.RESET}] Retry - Test again")
+        print(f"  [{Colors.CYAN}e{Colors.RESET}] Edit - Modify the command")
+
+        while True:
+            choice = input(f"\n{Colors.CYAN}Your choice: {Colors.RESET}").lower().strip()
+
+            if choice == 'y':
+                # Record successful test
+                self.record_test_result(api_level, 'pass', result.stdout, version_obj)
+                return True
+            elif choice == 'n':
+                print(f"{Colors.RED}Command must work to be added!{Colors.RESET}")
+                notes = input("What went wrong? ")
+                self.record_test_result(api_level, 'fail', error=result.stderr, notes=notes, version_obj=version_obj)
+                return False
+            elif choice == 'r':
+                return self.test_command()
+            elif choice == 'e':
+                # Allow editing the command
+                if version_obj:
+                    new_cmd = self.prompt_input("Enter corrected command", default=command)
+                    version_obj['mac'] = new_cmd
+                    if not self.prompt_yes_no("Same for Windows?", True):
+                        version_obj['windows'] = self.prompt_input("Windows command")
+                    else:
+                        version_obj['windows'] = new_cmd
+                else:
+                    new_cmd = self.prompt_input("Enter corrected command", default=command)
+                    self.new_command['mac'] = new_cmd
+                    if not self.prompt_yes_no("Same for Windows?", True):
+                        self.new_command['windows'] = self.prompt_input("Windows command")
+                    else:
+                        self.new_command['windows'] = new_cmd
+                return self.test_command()
+
+    def record_test_result(self, api_level: str, status: str, output: str = None,
+                          error: str = None, notes: str = None, version_obj: Dict = None):
+        """Record the test result"""
+        test_result = {
+            'status': status,
+            'date': datetime.now().strftime('%Y-%m-%d'),
+            'output': output if status == 'pass' else None,
+            'error': error if status == 'fail' else None,
+            'notes': notes if notes else None
+        }
+
+        if version_obj:
+            # Multi-version command
+            if 'verification' not in version_obj:
+                version_obj['verification'] = {
+                    'verified': False,
+                    'lastTested': None,
+                    'testedVersions': {}
+                }
+            version_obj['verification']['testedVersions'][api_level] = test_result
+            version_obj['verification']['verified'] = status == 'pass'
+            version_obj['verification']['lastTested'] = datetime.now().strftime('%Y-%m-%d')
+
+            # Update overall
+            self.new_command['verification']['verified'] = status == 'pass'
+            self.new_command['verification']['lastTested'] = datetime.now().strftime('%Y-%m-%d')
+            self.new_command['verification']['overallStatus'] = 'tested'
+        else:
+            # Single version command
+            if 'verification' not in self.new_command:
+                self.new_command['verification'] = {
+                    'verified': False,
+                    'lastTested': None,
+                    'testedVersions': {}
+                }
+            self.new_command['verification']['testedVersions'][api_level] = test_result
+            self.new_command['verification']['verified'] = status == 'pass'
+            self.new_command['verification']['lastTested'] = datetime.now().strftime('%Y-%m-%d')
+
+    def preview_command(self):
+        """Show preview of the new command"""
+        print(f"\n{Colors.BOLD}{Colors.GREEN}=== Command Preview ==={Colors.RESET}")
+        print(json.dumps(self.new_command, indent=2))
+
+    def add_command(self):
+        """Main flow for adding a new command"""
+        print(f"{Colors.BOLD}{Colors.CYAN}=== Add New ADB Command ==={Colors.RESET}")
+
+        # Get command details
+        self.get_basic_info()
+        self.get_command_syntax()
+
+        # Preview
+        self.preview_command()
+
+        # Test the command
+        if not self.prompt_yes_no("\nReady to test the command?", True):
+            print(f"{Colors.YELLOW}Command not added (testing required){Colors.RESET}")
+            return False
+
+        if not self.test_command():
+            if not self.prompt_yes_no("Testing failed. Try again?", True):
+                print(f"{Colors.RED}Command not added (must pass testing){Colors.RESET}")
+                return False
+            # Retry
+            return self.add_command()
+
+        # Confirm addition
+        print(f"\n{Colors.GREEN}✓ Command tested successfully!{Colors.RESET}")
+        self.preview_command()
+
+        if not self.prompt_yes_no("\nAdd this command to commands.json?", True):
+            print(f"{Colors.YELLOW}Command not added{Colors.RESET}")
+            return False
+
+        # Add to commands list
+        self.commands.append(self.new_command)
+
+        # Save
+        self.save_commands()
+
+        print(f"\n{Colors.GREEN}✓ Command added successfully!{Colors.RESET}")
+        print(f"  ID: {self.new_command['id']}")
+        print(f"  Title: {self.new_command['title']}")
+        print(f"  Verified on API: {list(self.new_command['verification']['testedVersions'].keys())}")
+
+        return True
+
+    def interactive_mode(self):
+        """Interactive mode for adding multiple commands"""
+        while True:
+            self.new_command = {}
+
+            if self.add_command():
+                print(f"\n{Colors.GREEN}Command added!{Colors.RESET}")
+            else:
+                print(f"\n{Colors.YELLOW}Command not added{Colors.RESET}")
+
+            if not self.prompt_yes_no("\nAdd another command?", False):
+                break
+
+        print(f"\n{Colors.CYAN}Total commands: {len(self.commands)}{Colors.RESET}")
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='Add new ADB commands with verification',
+        epilog="""
+This tool helps you add new ADB commands to commands.json.
+Each command must be tested on at least one Android version before being added.
+
+Example workflow:
+1. Run the script
+2. Enter command details
+3. Test on connected device/emulator
+4. Command is added if test passes
+        """
+    )
+
+    parser.add_argument('--quick', action='store_true',
+                       help='Quick mode - skip some optional fields')
+
+    args = parser.parse_args()
+
+    print(f"{Colors.BOLD}{Colors.CYAN}ADB Command Addition Tool{Colors.RESET}")
+
+    # Check for ADB
+    try:
+        result = subprocess.run(['adb', 'version'], capture_output=True, text=True)
+        if result.returncode != 0:
+            print(f"{Colors.RED}Error: ADB not found!{Colors.RESET}")
+            print("Please install Android SDK platform-tools")
+            sys.exit(1)
+    except FileNotFoundError:
+        print(f"{Colors.RED}Error: ADB not found!{Colors.RESET}")
+        print("Please install Android SDK platform-tools")
+        sys.exit(1)
+
+    adder = CommandAdder()
+
+    try:
+        adder.interactive_mode()
+    except KeyboardInterrupt:
+        print(f"\n{Colors.YELLOW}Interrupted by user{Colors.RESET}")
+    except Exception as e:
+        print(f"{Colors.RED}Error: {e}{Colors.RESET}")
+        import traceback
+        traceback.print_exc()
+
+if __name__ == '__main__':
+    main()

--- a/tools/adb-cmd/utils/analyze_commands.py
+++ b/tools/adb-cmd/utils/analyze_commands.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""
+Command Analyzer and Optimizer
+Analyzes commands.json to suggest optimal version groupings
+"""
+
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple, Set
+from collections import defaultdict
+
+class CommandAnalyzer:
+    def __init__(self, commands_file="../data/commands.json"):
+        self.commands_file = Path(__file__).parent.parent / 'data' / 'commands.json'
+        self.commands = self.load_commands()
+
+        # API level mappings
+        self.api_to_version = {
+            14: '4.0', 15: '4.0.3', 16: '4.1', 17: '4.2', 18: '4.3', 19: '4.4',
+            21: '5.0', 22: '5.1',
+            23: '6.0',
+            24: '7.0', 25: '7.1',
+            26: '8.0', 27: '8.1',
+            28: '9.0', 29: '10.0',
+            30: '11.0', 31: '12.0', 32: '12L', 33: '13.0',
+            34: '14.0', 35: '15.0', 36: '16.0',
+        }
+
+        self.version_to_api = {v: k for k, v in self.api_to_version.items()}
+        # Add simplified versions
+        self.version_to_api.update({
+            '9': 28, '10': 29, '11': 30, '12': 31, '13': 33,
+            '14': 34, '15': 35, '16': 36
+        })
+
+    def load_commands(self) -> List[Dict]:
+        """Load commands from JSON file"""
+        with open(self.commands_file, 'r') as f:
+            return json.load(f)
+
+    def analyze_multiversion_commands(self):
+        """Analyze multi-version commands for optimization opportunities"""
+        print("\n=== MULTI-VERSION COMMAND ANALYSIS ===\n")
+
+        for cmd in self.commands:
+            if not cmd.get('multiVersion'):
+                continue
+
+            print(f"Command: {cmd['title']} (ID: {cmd['id']})")
+            print(f"Category: {cmd['category']}")
+
+            versions = cmd.get('versions', [])
+            if not versions:
+                print("  No versions found!\n")
+                continue
+
+            # Analyze command similarity
+            command_groups = self.group_similar_commands(versions)
+
+            if len(command_groups) < len(versions):
+                print(f"  Current: {len(versions)} separate version entries")
+                print(f"  Could be: {len(command_groups)} groups\n")
+
+                print("  Suggested groupings:")
+                for group in command_groups:
+                    ranges = [v['range'] for v in group['versions']]
+                    consolidated_range = self.suggest_range(ranges)
+                    print(f"    • {consolidated_range}:")
+                    print(f"      Windows: {group['windows']}")
+                    print(f"      Mac: {group['mac']}")
+
+            else:
+                print(f"  ✓ Already optimally grouped ({len(versions)} unique commands)\n")
+
+    def group_similar_commands(self, versions: List[Dict]) -> List[Dict]:
+        """Group versions with identical commands"""
+        groups = []
+
+        for version in versions:
+            # Check if this command already exists in a group
+            found = False
+            for group in groups:
+                if (group['windows'] == version.get('windows') and
+                    group['mac'] == version.get('mac')):
+                    group['versions'].append(version)
+                    found = True
+                    break
+
+            if not found:
+                # Create new group
+                groups.append({
+                    'windows': version.get('windows'),
+                    'mac': version.get('mac'),
+                    'versions': [version]
+                })
+
+        return groups
+
+    def suggest_range(self, ranges: List[str]) -> str:
+        """Suggest an optimal range string for grouped versions"""
+        # Parse all ranges to get API levels
+        api_levels = set()
+
+        for range_str in ranges:
+            if '+' in range_str:
+                # e.g., "12+"
+                base = range_str.replace('+', '')
+                base_api = self.version_to_api.get(base, 0)
+                # Add a range of APIs
+                api_levels.update(range(base_api, 37))  # Up to API 36
+            elif ' - ' in range_str:
+                # e.g., "4.0 - 10.0"
+                parts = range_str.split(' - ')
+                start_api = self.version_to_api.get(parts[0], 0)
+                end_api = self.version_to_api.get(parts[1], 36)
+                api_levels.update(range(start_api, end_api + 1))
+            else:
+                # Single version
+                api = self.version_to_api.get(range_str, 0)
+                if api:
+                    api_levels.add(api)
+
+        if not api_levels:
+            return " + ".join(ranges)
+
+        # Convert back to version range
+        min_api = min(api_levels)
+        max_api = max(api_levels)
+
+        # Check if it's continuous
+        expected_apis = set(range(min_api, max_api + 1))
+        if api_levels == expected_apis:
+            # Continuous range
+            min_ver = self.api_to_version.get(min_api, str(min_api))
+
+            # Simplify version numbers
+            min_ver = self.simplify_version(min_ver)
+
+            if max_api == 36:  # Latest version
+                return f"{min_ver}+"
+            else:
+                max_ver = self.api_to_version.get(max_api, str(max_api))
+                max_ver = self.simplify_version(max_ver)
+                return f"{min_ver} - {max_ver}"
+        else:
+            # Non-continuous, list them
+            versions = []
+            for api in sorted(api_levels):
+                ver = self.api_to_version.get(api, str(api))
+                versions.append(self.simplify_version(ver))
+            return ", ".join(versions)
+
+    def simplify_version(self, version: str) -> str:
+        """Simplify version string (e.g., '12.0' -> '12')"""
+        if version.endswith('.0') and len(version) > 3:
+            return version[:-2]
+        return version
+
+    def check_command_consistency(self):
+        """Check for potential issues in command definitions"""
+        print("\n=== COMMAND CONSISTENCY CHECK ===\n")
+
+        issues_found = False
+
+        for cmd in self.commands:
+            if cmd.get('multiVersion'):
+                versions = cmd.get('versions', [])
+
+                # Check for overlapping ranges
+                for i, v1 in enumerate(versions):
+                    for j, v2 in enumerate(versions[i+1:], i+1):
+                        if self.ranges_overlap(v1['range'], v2['range']):
+                            print(f"⚠ Overlapping ranges in '{cmd['title']}':")
+                            print(f"  Version {i+1}: {v1['range']}")
+                            print(f"  Version {j+1}: {v2['range']}")
+                            issues_found = True
+
+                # Check for gaps in coverage
+                gaps = self.find_coverage_gaps(versions)
+                if gaps:
+                    print(f"⚠ Coverage gaps in '{cmd['title']}':")
+                    print(f"  Missing Android versions: {', '.join(gaps)}")
+                    issues_found = True
+
+        if not issues_found:
+            print("✓ No consistency issues found!")
+
+    def ranges_overlap(self, range1: str, range2: str) -> bool:
+        """Check if two version ranges overlap"""
+        apis1 = self.parse_range_to_apis(range1)
+        apis2 = self.parse_range_to_apis(range2)
+        return bool(apis1 & apis2)
+
+    def parse_range_to_apis(self, range_str: str) -> Set[int]:
+        """Parse a range string to a set of API levels"""
+        apis = set()
+
+        if range_str == 'All':
+            return set(range(14, 37))
+        elif '+' in range_str:
+            base = range_str.replace('+', '')
+            base_api = self.version_to_api.get(base, 0)
+            apis.update(range(base_api, 37))
+        elif ' - ' in range_str:
+            parts = range_str.split(' - ')
+            start_api = self.version_to_api.get(parts[0], 0)
+            end_api = self.version_to_api.get(parts[1], 36)
+            apis.update(range(start_api, end_api + 1))
+        else:
+            api = self.version_to_api.get(range_str, 0)
+            if api:
+                apis.add(api)
+
+        return apis
+
+    def find_coverage_gaps(self, versions: List[Dict]) -> List[str]:
+        """Find gaps in version coverage"""
+        covered_apis = set()
+
+        for version in versions:
+            covered_apis.update(self.parse_range_to_apis(version['range']))
+
+        # Check for gaps between API 14 (4.0) and 36 (16.0)
+        all_apis = set(range(14, 37))
+        missing_apis = all_apis - covered_apis
+
+        # Convert to version strings
+        missing_versions = []
+        for api in sorted(missing_apis):
+            ver = self.api_to_version.get(api, f"API {api}")
+            missing_versions.append(self.simplify_version(ver))
+
+        return missing_versions
+
+    def suggest_consolidation(self):
+        """Provide specific consolidation recommendations"""
+        print("\n=== CONSOLIDATION RECOMMENDATIONS ===\n")
+
+        for cmd in self.commands:
+            if not cmd.get('multiVersion'):
+                continue
+
+            versions = cmd.get('versions', [])
+            if len(versions) <= 2:
+                continue
+
+            # Group by command
+            command_groups = self.group_similar_commands(versions)
+
+            if len(command_groups) < len(versions):
+                print(f"Command: {cmd['title']} (ID: {cmd['id']})")
+                print(f"Current structure has {len(versions)} entries")
+                print(f"Recommended structure with {len(command_groups)} entries:\n")
+
+                print("  \"versions\": [")
+                for i, group in enumerate(command_groups):
+                    ranges = [v['range'] for v in group['versions']]
+                    consolidated_range = self.suggest_range(ranges)
+
+                    # Get the best notes
+                    all_notes = [v.get('notes', '') for v in group['versions'] if v.get('notes')]
+                    notes = all_notes[0] if all_notes else ""
+
+                    print("    {")
+                    print(f'      "range": "{consolidated_range}",')
+                    print(f'      "windows": "{group["windows"]}",')
+                    print(f'      "mac": "{group["mac"]}",')
+                    print(f'      "notes": "{notes}"')
+
+                    if i < len(command_groups) - 1:
+                        print("    },")
+                    else:
+                        print("    }")
+                print("  ]\n")
+
+def main():
+    analyzer = CommandAnalyzer()
+
+    print("=" * 70)
+    print("ADB COMMAND STRUCTURE ANALYZER")
+    print("=" * 70)
+
+    # Run analysis
+    analyzer.analyze_multiversion_commands()
+    analyzer.check_command_consistency()
+    analyzer.suggest_consolidation()
+
+    print("\n" + "=" * 70)
+    print("Analysis complete!")
+
+if __name__ == '__main__':
+    main()

--- a/tools/adb-cmd/utils/manual_verify.py
+++ b/tools/adb-cmd/utils/manual_verify.py
@@ -1,0 +1,895 @@
+#!/usr/bin/env python3
+"""
+Manual ADB Command Verifier
+Interactive tool for testing and verifying ADB commands across Android versions
+"""
+
+import json
+import sys
+import subprocess
+import platform
+import argparse
+from pathlib import Path
+from datetime import datetime
+from typing import Dict, List, Optional, Any
+import shutil
+import os
+import asyncio
+
+# Import from local modules
+from modules.emulator_manager import EmulatorManager
+
+# ANSI color codes for terminal output
+class Colors:
+    CYAN = '\033[96m'
+    GREEN = '\033[92m'
+    YELLOW = '\033[93m'
+    RED = '\033[91m'
+    WHITE = '\033[97m'
+    BOLD = '\033[1m'
+    RESET = '\033[0m'
+
+class ManualVerifier:
+    def __init__(self, commands_file="../data/commands.json", auto_backup=True):
+        self.commands_file = Path(__file__).parent.parent / 'data' / 'commands.json'
+        self.backup_dir = self.commands_file.parent / 'backups'
+        self.auto_backup = auto_backup
+        self.is_mac = platform.system() == 'Darwin'  # Set this before setup_android_sdk_path
+        self.commands = self.load_commands()
+        self.setup_android_sdk_path()
+        self.em = EmulatorManager()
+        self.current_device = None
+        self.current_api = None
+        self.session_stats = {
+            'tested': 0,
+            'passed': 0,
+            'failed': 0,
+            'skipped': 0
+        }
+
+    def setup_android_sdk_path(self):
+        """Setup Android SDK paths in environment"""
+        # Common Android SDK locations
+        sdk_paths = []
+
+        # Check ANDROID_HOME and ANDROID_SDK_ROOT environment variables
+        android_home = os.environ.get('ANDROID_HOME')
+        android_sdk_root = os.environ.get('ANDROID_SDK_ROOT')
+
+        if android_home:
+            sdk_paths.append(Path(android_home))
+        if android_sdk_root:
+            sdk_paths.append(Path(android_sdk_root))
+
+        # Check common locations
+        home = Path.home()
+        if self.is_mac:
+            sdk_paths.extend([
+                home / 'Library' / 'Android' / 'sdk',
+                Path('/usr/local/share/android-sdk'),
+                Path('/opt/android-sdk')
+            ])
+        else:  # Windows/Linux
+            sdk_paths.extend([
+                home / 'Android' / 'Sdk',
+                home / 'android-sdk',
+                Path('/opt/android-sdk')
+            ])
+
+        # Find the first existing SDK path
+        sdk_path = None
+        for path in sdk_paths:
+            if path.exists():
+                sdk_path = path
+                break
+
+        if sdk_path:
+            # Add SDK tools to PATH
+            emulator_path = sdk_path / 'emulator'
+            platform_tools = sdk_path / 'platform-tools'
+            cmdline_tools = sdk_path / 'cmdline-tools' / 'latest' / 'bin'
+            tools = sdk_path / 'tools' / 'bin'
+
+            paths_to_add = []
+            if emulator_path.exists():
+                paths_to_add.append(str(emulator_path))
+            if platform_tools.exists():
+                paths_to_add.append(str(platform_tools))
+            if cmdline_tools.exists():
+                paths_to_add.append(str(cmdline_tools))
+            if tools.exists():
+                paths_to_add.append(str(tools))
+
+            if paths_to_add:
+                current_path = os.environ.get('PATH', '')
+                new_path = os.pathsep.join(paths_to_add + [current_path])
+                os.environ['PATH'] = new_path
+                print(f"{Colors.GREEN}✓ Android SDK found at: {sdk_path}{Colors.RESET}")
+
+            # Also set ANDROID_HOME if not set
+            if not android_home:
+                os.environ['ANDROID_HOME'] = str(sdk_path)
+        else:
+            print(f"{Colors.YELLOW}⚠ Android SDK not found. Please set ANDROID_HOME environment variable.{Colors.RESET}")
+
+    def load_commands(self) -> List[Dict]:
+        """Load commands from JSON file"""
+        with open(self.commands_file, 'r') as f:
+            return json.load(f)
+
+    def save_commands(self, create_backup=True):
+        """Save commands to JSON file with optional backup"""
+        if create_backup and self.auto_backup:
+            self.create_backup()
+
+        with open(self.commands_file, 'w') as f:
+            json.dump(self.commands, f, indent=2)
+
+    def create_backup(self) -> Path:
+        """Create timestamped backup of commands.json"""
+        self.backup_dir.mkdir(exist_ok=True)
+        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+        backup_file = self.backup_dir / f'commands_{timestamp}.json'
+
+        shutil.copy2(self.commands_file, backup_file)
+        print(f"{Colors.GREEN}✓ Backup created: {backup_file.name}{Colors.RESET}")
+        return backup_file
+
+    def start_emulator(self, api_level: int) -> bool:
+        """Start emulator for testing using EmulatorManager"""
+        print(f"\n{Colors.CYAN}Starting Android {api_level} emulator...{Colors.RESET}")
+        self.current_api = api_level
+
+        # Construct AVD name
+        avd_name = f"test_android_{api_level}"
+
+        async def start_emulator_async():
+            # Check prerequisites
+            prereqs = await self.em.check_prerequisites()
+            if not all(prereqs.values()):
+                missing = [tool for tool, found in prereqs.items() if not found]
+                print(f"{Colors.RED}✗ Missing required tools: {', '.join(missing)}{Colors.RESET}")
+                print(f"{Colors.YELLOW}Please install Android SDK and ensure tools are in PATH{Colors.RESET}")
+                return None
+
+            # Check if AVD exists, create if needed
+            avds = await self.em.list_avds()
+            avd_exists = any(avd['name'] == avd_name for avd in avds)
+
+            if not avd_exists:
+                print(f"{Colors.YELLOW}AVD '{avd_name}' not found. Creating it...{Colors.RESET}")
+                success = await self.em.create_avd(avd_name, api_level)
+                if not success:
+                    print(f"{Colors.RED}✗ Failed to create AVD{Colors.RESET}")
+                    return None
+
+            # Start the emulator
+            emulator_info = await self.em.start_emulator(avd_name)
+            return emulator_info
+
+        # Run async function
+        try:
+            emulator_info = asyncio.run(start_emulator_async())
+            if emulator_info:
+                self.current_device = emulator_info.serial
+                print(f"{Colors.GREEN}✓ Emulator fully started: {self.current_device}{Colors.RESET}")
+                return True
+            else:
+                return False
+        except Exception as e:
+            print(f"{Colors.RED}Error starting emulator: {e}{Colors.RESET}")
+            return False
+
+    def stop_emulator(self):
+        """Stop the current emulator"""
+        if self.current_device:
+            print(f"\n{Colors.YELLOW}Stopping emulator...{Colors.RESET}")
+            try:
+                asyncio.run(self.em.stop_emulator(self.current_device))
+                print(f"{Colors.GREEN}✓ Emulator stopped{Colors.RESET}")
+            except Exception as e:
+                print(f"{Colors.YELLOW}Warning: Could not stop emulator cleanly: {e}{Colors.RESET}")
+                # Fallback to direct adb command
+                subprocess.run(['adb', '-s', self.current_device, 'emu', 'kill'], capture_output=True)
+            self.current_device = None
+
+    def get_command_for_platform(self, cmd_data: Dict, version: Optional[Dict] = None) -> str:
+        """Get the appropriate command for current platform"""
+        if version:
+            return version['mac'] if self.is_mac else version['windows']
+        else:
+            return cmd_data['mac'] if self.is_mac else cmd_data['windows']
+
+    def execute_command(self, command: str) -> Dict[str, Any]:
+        """Execute ADB command and return results"""
+        if not self.current_device:
+            return {
+                'success': False,
+                'stdout': '',
+                'stderr': 'No device connected',
+                'returncode': -1
+            }
+
+        # Replace 'adb' with 'adb -s device_serial' for specific device
+        if command.startswith('adb '):
+            command = f"adb -s {self.current_device} {command[4:]}"
+        elif command == 'adb':
+            command = f"adb -s {self.current_device}"
+
+        try:
+            result = subprocess.run(
+                command,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=30
+            )
+
+            return {
+                'success': result.returncode == 0,
+                'stdout': result.stdout,
+                'stderr': result.stderr,
+                'returncode': result.returncode
+            }
+        except subprocess.TimeoutExpired:
+            return {
+                'success': False,
+                'stdout': '',
+                'stderr': 'Command timeout (30s)',
+                'returncode': -1
+            }
+        except Exception as e:
+            return {
+                'success': False,
+                'stdout': '',
+                'stderr': str(e),
+                'returncode': -1
+            }
+
+    def display_command_info(self, cmd_data: Dict, index: int, total: int):
+        """Display command information"""
+        print(f"\n{Colors.YELLOW}{'='*70}{Colors.RESET}")
+        print(f"{Colors.BOLD}{Colors.CYAN}[{index}/{total}] Testing: {cmd_data['title']}{Colors.RESET}")
+        print(f"{Colors.WHITE}Description: {cmd_data['description']}{Colors.RESET}")
+        print(f"Category: {cmd_data['category']}")
+        print(f"ID: {cmd_data['id']}")
+
+        # Show existing verification status for this API level
+        if 'verification' in cmd_data and 'testedVersions' in cmd_data['verification']:
+            api_str = str(self.current_api)
+            if api_str in cmd_data['verification']['testedVersions']:
+                prev = cmd_data['verification']['testedVersions'][api_str]
+                status_color = Colors.GREEN if prev['status'] == 'pass' else Colors.RED
+                print(f"\n{Colors.YELLOW}Previous test on API {self.current_api}:{Colors.RESET}")
+                print(f"  Status: {status_color}{prev['status']}{Colors.RESET}")
+                print(f"  Date: {prev['date']}")
+                if prev.get('notes'):
+                    print(f"  Notes: {prev['notes']}")
+
+    def test_command(self, cmd_data: Dict, index: int, total: int) -> Optional[Dict]:
+        """Test a single command with manual verification"""
+        self.display_command_info(cmd_data, index, total)
+
+        # Handle multi-version commands
+        if cmd_data.get('multiVersion'):
+            return self.test_multiversion_command(cmd_data, index, total)
+        else:
+            return self.test_standard_command(cmd_data, index, total)
+
+    def test_standard_command(self, cmd_data: Dict, index: int, total: int) -> Optional[Dict]:
+        """Test a standard (non-multiversion) command"""
+        command = self.get_command_for_platform(cmd_data)
+
+        print(f"\n{Colors.CYAN}Command: {Colors.WHITE}{command}{Colors.RESET}")
+
+        # Execute command
+        print(f"\n{Colors.CYAN}Executing...{Colors.RESET}")
+        result = self.execute_command(command)
+
+        # Display results
+        self.display_results(result)
+
+        # Get user verification
+        verdict = self.get_user_verdict()
+
+        if verdict == 'skip':
+            self.session_stats['skipped'] += 1
+            return None
+        elif verdict == 'retry':
+            return self.test_standard_command(cmd_data, index, total)
+        elif verdict == 'edit':
+            # Allow user to edit the command
+            print(f"\n{Colors.YELLOW}Current command: {Colors.RESET}{command}")
+            new_command = input(f"{Colors.CYAN}Enter new command: {Colors.RESET}")
+            if new_command.strip():
+                # Update the command in the data structure
+                if self.is_mac:
+                    cmd_data['mac'] = new_command.strip()
+                else:
+                    cmd_data['windows'] = new_command.strip()
+                print(f"{Colors.GREEN}✓ Command updated{Colors.RESET}")
+            return self.test_standard_command(cmd_data, index, total)
+
+        # Record result
+        self.session_stats['tested'] += 1
+
+        if verdict == 'pass':
+            self.session_stats['passed'] += 1
+            self.record_verification(cmd_data, 'pass', result['stdout'])
+        elif verdict == 'fail':
+            self.session_stats['failed'] += 1
+            notes = input("Notes about failure (optional): ")
+            self.record_verification(cmd_data, 'fail', error=result['stderr'], notes=notes)
+        elif verdict == 'paste':
+            print("Paste the expected output (end with '###' on new line):")
+            lines = []
+            while True:
+                line = input()
+                if line == '###':
+                    break
+                lines.append(line)
+            output = '\n'.join(lines)
+            self.session_stats['passed'] += 1
+            self.record_verification(cmd_data, 'pass', output)
+
+        return cmd_data
+
+    def test_multiversion_command(self, cmd_data: Dict, index: int, total: int) -> Optional[Dict]:
+        """Test a multi-version command"""
+        print(f"\n{Colors.CYAN}Multi-version command detected:{Colors.RESET}")
+
+        # Find the appropriate version for current API
+        selected_version = None
+        for i, version in enumerate(cmd_data.get('versions', [])):
+            print(f"  [{i+1}] {version['range']}: {self.get_command_for_platform(cmd_data, version)}")
+
+            # Check if this version applies to current API
+            if self.version_applies_to_api(version['range'], self.current_api):
+                selected_version = version
+                print(f"  {Colors.GREEN}→ Using version {i+1} for API {self.current_api}{Colors.RESET}")
+
+        if not selected_version:
+            print(f"{Colors.YELLOW}No version found for API {self.current_api}{Colors.RESET}")
+            return None
+
+        command = self.get_command_for_platform(cmd_data, selected_version)
+        print(f"\n{Colors.CYAN}Command: {Colors.WHITE}{command}{Colors.RESET}")
+
+        # Execute command
+        print(f"\n{Colors.CYAN}Executing...{Colors.RESET}")
+        result = self.execute_command(command)
+
+        # Display results
+        self.display_results(result)
+
+        # Get user verification
+        verdict = self.get_user_verdict()
+
+        if verdict == 'skip':
+            self.session_stats['skipped'] += 1
+            return None
+        elif verdict == 'retry':
+            return self.test_multiversion_command(cmd_data, index, total)
+        elif verdict == 'edit':
+            # Allow user to edit the command for this specific version
+            print(f"\n{Colors.YELLOW}Current command for {selected_version['range']}: {Colors.RESET}{command}")
+            new_command = input(f"{Colors.CYAN}Enter new command: {Colors.RESET}")
+            if new_command.strip():
+                # Update the command for this version
+                if self.is_mac:
+                    selected_version['mac'] = new_command.strip()
+                else:
+                    selected_version['windows'] = new_command.strip()
+                print(f"{Colors.GREEN}✓ Command updated for version {selected_version['range']}{Colors.RESET}")
+            return self.test_multiversion_command(cmd_data, index, total)
+
+        # Record result for this version
+        self.session_stats['tested'] += 1
+
+        if verdict == 'pass':
+            self.session_stats['passed'] += 1
+            self.record_version_verification(selected_version, 'pass', result['stdout'])
+            self.update_overall_verification(cmd_data)
+        elif verdict == 'fail':
+            self.session_stats['failed'] += 1
+            notes = input("Notes about failure (optional): ")
+            self.record_version_verification(selected_version, 'fail', error=result['stderr'], notes=notes)
+            self.update_overall_verification(cmd_data)
+        elif verdict == 'paste':
+            print("Paste the expected output (end with '###' on new line):")
+            lines = []
+            while True:
+                line = input()
+                if line == '###':
+                    break
+                lines.append(line)
+            output = '\n'.join(lines)
+            self.session_stats['passed'] += 1
+            self.record_version_verification(selected_version, 'pass', output)
+            self.update_overall_verification(cmd_data)
+
+        return cmd_data
+
+    def version_applies_to_api(self, version_range: str, api_level: int) -> bool:
+        """Check if a version range applies to given API level"""
+        # Simple version mapping (extend as needed)
+        version_to_api = {
+            '4.0': 14, '4.1': 16, '4.2': 17, '4.3': 18, '4.4': 19,
+            '5.0': 21, '5.1': 22,
+            '6.0': 23,
+            '7.0': 24, '7.1': 25,
+            '8.0': 26, '8.1': 27,
+            '9.0': 28, '9': 28,
+            '10.0': 29, '10': 29,
+            '11.0': 30, '11': 30,
+            '12.0': 31, '12': 31, '12L': 32,
+            '13.0': 33, '13': 33,
+            '14.0': 34, '14': 34,
+            '15.0': 35, '15': 35,
+            '16.0': 36, '16': 36,
+        }
+
+        # Handle special cases
+        if version_range == 'All':
+            return True
+        elif '+' in version_range:
+            # e.g., "12+"
+            min_version = version_range.replace('+', '')
+            min_api = version_to_api.get(min_version, 0)
+            return api_level >= min_api
+        elif ' - ' in version_range:
+            # e.g., "4.0 - 10.0"
+            parts = version_range.split(' - ')
+            min_api = version_to_api.get(parts[0], 0)
+            max_api = version_to_api.get(parts[1], 99)
+            return min_api <= api_level <= max_api
+        else:
+            # Single version
+            target_api = version_to_api.get(version_range, 0)
+            return api_level == target_api
+
+    def display_results(self, result: Dict[str, Any]):
+        """Display command execution results"""
+        if result['stdout']:
+            print(f"\n{Colors.GREEN}STDOUT:{Colors.RESET}")
+            # Limit output display
+            lines = result['stdout'].split('\n')
+            if len(lines) > 20:
+                print('\n'.join(lines[:20]))
+                print(f"{Colors.YELLOW}... ({len(lines)-20} more lines){Colors.RESET}")
+            else:
+                print(result['stdout'])
+        else:
+            print(f"\n{Colors.GREEN}STDOUT:{Colors.RESET} (empty)")
+
+        if result['stderr']:
+            print(f"\n{Colors.RED}STDERR:{Colors.RESET}")
+            print(result['stderr'])
+
+        print(f"\n{Colors.CYAN}Return code: {result['returncode']}{Colors.RESET}")
+
+    def get_user_verdict(self) -> str:
+        """Get verification verdict from user"""
+        print(f"\n{Colors.YELLOW}{'='*70}{Colors.RESET}")
+        print("Verification Options:")
+        print(f"  [{Colors.GREEN}p{Colors.RESET}] Pass - Command worked as expected")
+        print(f"  [{Colors.RED}f{Colors.RESET}] Fail - Command failed or unexpected output")
+        print(f"  [{Colors.YELLOW}s{Colors.RESET}] Skip - Skip this command")
+        print(f"  [{Colors.CYAN}r{Colors.RESET}] Retry - Run command again")
+        print(f"  [{Colors.CYAN}e{Colors.RESET}] Edit - Modify the command")
+        print(f"  [{Colors.CYAN}o{Colors.RESET}] Paste Output - Manually provide expected output")
+        print(f"  [{Colors.RED}q{Colors.RESET}] Quit - Save and exit")
+
+        while True:
+            choice = input(f"\n{Colors.CYAN}Your verdict: {Colors.RESET}").lower().strip()
+
+            if choice in ['p', 'pass']:
+                return 'pass'
+            elif choice in ['f', 'fail']:
+                return 'fail'
+            elif choice in ['s', 'skip']:
+                return 'skip'
+            elif choice in ['r', 'retry']:
+                return 'retry'
+            elif choice in ['e', 'edit']:
+                return 'edit'
+            elif choice in ['o', 'output']:
+                return 'paste'
+            elif choice in ['q', 'quit']:
+                print(f"\n{Colors.YELLOW}Saving progress and exiting...{Colors.RESET}")
+                self.save_commands()
+                self.display_session_summary()
+                sys.exit(0)
+            else:
+                print(f"{Colors.RED}Invalid choice. Please try again.{Colors.RESET}")
+
+    def record_verification(self, cmd_data: Dict, status: str, output: str = None, error: str = None, notes: str = None):
+        """Record verification result for standard command"""
+        if 'verification' not in cmd_data:
+            cmd_data['verification'] = {
+                'verified': False,
+                'lastTested': None,
+                'testedVersions': {}
+            }
+
+        api_str = str(self.current_api)
+        cmd_data['verification']['testedVersions'][api_str] = {
+            'status': status,
+            'date': datetime.now().strftime('%Y-%m-%d'),
+            'output': output if status == 'pass' else None,
+            'error': error if status == 'fail' else None,
+            'notes': notes if notes else None
+        }
+
+        cmd_data['verification']['lastTested'] = datetime.now().strftime('%Y-%m-%d')
+
+        # Update overall verified flag
+        any_passed = any(
+            v['status'] == 'pass'
+            for v in cmd_data['verification']['testedVersions'].values()
+        )
+        cmd_data['verification']['verified'] = any_passed
+
+    def record_version_verification(self, version: Dict, status: str, output: str = None, error: str = None, notes: str = None):
+        """Record verification result for a specific version of multi-version command"""
+        if 'verification' not in version:
+            version['verification'] = {
+                'verified': False,
+                'lastTested': None,
+                'testedVersions': {}
+            }
+
+        api_str = str(self.current_api)
+        version['verification']['testedVersions'][api_str] = {
+            'status': status,
+            'date': datetime.now().strftime('%Y-%m-%d'),
+            'output': output if status == 'pass' else None,
+            'error': error if status == 'fail' else None,
+            'notes': notes if notes else None
+        }
+
+        version['verification']['lastTested'] = datetime.now().strftime('%Y-%m-%d')
+        version['verification']['verified'] = status == 'pass'
+
+    def update_overall_verification(self, cmd_data: Dict):
+        """Update overall verification status for multi-version command"""
+        if 'verification' not in cmd_data:
+            cmd_data['verification'] = {
+                'verified': False,
+                'lastTested': None,
+                'overallStatus': 'untested'
+            }
+
+        # Check if any version is verified
+        any_verified = False
+        for version in cmd_data.get('versions', []):
+            if version.get('verification', {}).get('verified'):
+                any_verified = True
+                break
+
+        cmd_data['verification']['verified'] = any_verified
+        cmd_data['verification']['lastTested'] = datetime.now().strftime('%Y-%m-%d')
+        cmd_data['verification']['overallStatus'] = 'partial' if any_verified else 'untested'
+
+    def display_session_summary(self):
+        """Display summary of testing session"""
+        print(f"\n{Colors.GREEN}{'='*70}{Colors.RESET}")
+        print(f"{Colors.BOLD}{Colors.CYAN}Session Summary{Colors.RESET}")
+        print(f"  Commands tested: {self.session_stats['tested']}")
+        print(f"  {Colors.GREEN}Passed: {self.session_stats['passed']}{Colors.RESET}")
+        print(f"  {Colors.RED}Failed: {self.session_stats['failed']}{Colors.RESET}")
+        print(f"  {Colors.YELLOW}Skipped: {self.session_stats['skipped']}{Colors.RESET}")
+
+        if self.session_stats['tested'] > 0:
+            pass_rate = (self.session_stats['passed'] / self.session_stats['tested']) * 100
+            print(f"  Pass rate: {pass_rate:.1f}%")
+
+    def analyze_for_consolidation(self, cmd_id: int):
+        """Analyze a multi-version command for consolidation opportunities"""
+        cmd = next((c for c in self.commands if c['id'] == cmd_id), None)
+        if not cmd or not cmd.get('multiVersion'):
+            return None
+
+        versions = cmd.get('versions', [])
+        if len(versions) <= 1:
+            return None
+
+        # Group versions by identical commands
+        groups = []
+        for version in versions:
+            found = False
+            for group in groups:
+                if (group['windows'] == version.get('windows') and
+                    group['mac'] == version.get('mac')):
+                    group['versions'].append(version)
+                    found = True
+                    break
+
+            if not found:
+                groups.append({
+                    'windows': version.get('windows'),
+                    'mac': version.get('mac'),
+                    'versions': [version]
+                })
+
+        # If we can consolidate
+        if len(groups) < len(versions):
+            return groups
+        return None
+
+    def suggest_version_consolidation(self, cmd_id: int):
+        """Suggest consolidation for a multi-version command"""
+        groups = self.analyze_for_consolidation(cmd_id)
+        if not groups:
+            return False
+
+        cmd = next((c for c in self.commands if c['id'] == cmd_id), None)
+
+        print(f"\n{Colors.YELLOW}{'='*70}{Colors.RESET}")
+        print(f"{Colors.BOLD}{Colors.YELLOW}CONSOLIDATION OPPORTUNITY DETECTED{Colors.RESET}")
+        print(f"Command: {cmd['title']}")
+        print(f"\nCurrent: {len(cmd['versions'])} separate versions")
+        print(f"Could be: {len(groups)} consolidated groups")
+
+        print(f"\n{Colors.CYAN}Suggested consolidation:{Colors.RESET}")
+        for i, group in enumerate(groups, 1):
+            ranges = [v['range'] for v in group['versions']]
+            print(f"\n  Group {i}: {', '.join(ranges)}")
+            print(f"    Windows: {group['windows']}")
+            print(f"    Mac: {group['mac']}")
+
+        response = input(f"\n{Colors.YELLOW}Apply consolidation? [y/n]: {Colors.RESET}").lower()
+
+        if response in ['y', 'yes']:
+            self.apply_consolidation(cmd_id, groups)
+            return True
+        return False
+
+    def apply_consolidation(self, cmd_id: int, groups):
+        """Apply the consolidation to the command"""
+        cmd = next((c for c in self.commands if c['id'] == cmd_id), None)
+        if not cmd:
+            return
+
+        new_versions = []
+
+        for group in groups:
+            # Combine ranges
+            ranges = [v['range'] for v in group['versions']]
+            consolidated_range = self.consolidate_ranges(ranges)
+
+            # Merge verification data
+            merged_verification = {
+                'verified': False,
+                'lastTested': None,
+                'testedVersions': {}
+            }
+
+            for version in group['versions']:
+                if 'verification' in version and 'testedVersions' in version['verification']:
+                    merged_verification['testedVersions'].update(version['verification']['testedVersions'])
+                    if version['verification'].get('verified'):
+                        merged_verification['verified'] = True
+                        merged_verification['lastTested'] = version['verification'].get('lastTested')
+
+            # Get the best notes
+            all_notes = [v.get('notes', '') for v in group['versions'] if v.get('notes')]
+            notes = all_notes[0] if all_notes else ""
+
+            new_version = {
+                'range': consolidated_range,
+                'windows': group['windows'],
+                'mac': group['mac'],
+                'notes': notes,
+                'verification': merged_verification
+            }
+
+            new_versions.append(new_version)
+
+        cmd['versions'] = new_versions
+        print(f"{Colors.GREEN}✓ Consolidation applied successfully{Colors.RESET}")
+
+    def consolidate_ranges(self, ranges):
+        """Consolidate multiple version ranges into one"""
+        # Simple version mapping
+        version_order = ['4.0', '4.1', '4.2', '4.3', '4.4', '5.0', '5.1', '6.0',
+                        '7.0', '7.1', '8.0', '8.1', '9.0', '10.0', '11', '12',
+                        '13', '14', '15', '16']
+
+        # Parse ranges to find min and max
+        all_versions = set()
+        has_plus = False
+
+        for range_str in ranges:
+            if range_str == 'All':
+                return 'All'
+            elif '+' in range_str:
+                has_plus = True
+                base = range_str.replace('+', '')
+                all_versions.add(base)
+                # Add all versions after this one
+                if base in version_order:
+                    idx = version_order.index(base)
+                    all_versions.update(version_order[idx:])
+            elif ' - ' in range_str:
+                parts = range_str.split(' - ')
+                if parts[0] in version_order and parts[1] in version_order:
+                    start_idx = version_order.index(parts[0])
+                    end_idx = version_order.index(parts[1])
+                    all_versions.update(version_order[start_idx:end_idx+1])
+            else:
+                all_versions.add(range_str)
+
+        # Sort versions
+        sorted_versions = []
+        for v in version_order:
+            if v in all_versions:
+                sorted_versions.append(v)
+
+        if not sorted_versions:
+            return ' + '.join(ranges)
+
+        # Check if continuous
+        first_idx = version_order.index(sorted_versions[0])
+        last_idx = version_order.index(sorted_versions[-1])
+        expected = version_order[first_idx:last_idx+1]
+
+        if sorted_versions == expected:
+            # Continuous range
+            if has_plus or last_idx == len(version_order) - 1:
+                return f"{sorted_versions[0]}+"
+            elif len(sorted_versions) == 1:
+                return sorted_versions[0]
+            else:
+                return f"{sorted_versions[0]} - {sorted_versions[-1]}"
+        else:
+            # Non-continuous
+            return ', '.join(sorted_versions)
+
+    def get_save_permission(self) -> bool:
+        """Ask user if they want to save changes"""
+        while True:
+            response = input(f"\n{Colors.YELLOW}Save changes to commands.json? [y/n]: {Colors.RESET}").lower()
+            if response in ['y', 'yes']:
+                return True
+            elif response in ['n', 'no']:
+                return False
+
+    def run_verification(self, api_level: int, category: Optional[str] = None,
+                         test_all: bool = False, start_from: int = 0):
+        """Run the verification session"""
+        # Start emulator
+        if not self.start_emulator(api_level):
+            return
+
+        # Filter commands
+        commands_to_test = self.commands
+
+        if category:
+            commands_to_test = [c for c in commands_to_test if c.get('category') == category]
+            print(f"\n{Colors.CYAN}Testing category: {category}{Colors.RESET}")
+
+        if not test_all:
+            # Filter out already verified commands for this API
+            unverified = []
+            for cmd in commands_to_test:
+                api_str = str(api_level)
+
+                # Check standard commands
+                if not cmd.get('multiVersion'):
+                    if not cmd.get('verification', {}).get('testedVersions', {}).get(api_str):
+                        unverified.append(cmd)
+                    elif cmd.get('verification', {}).get('testedVersions', {}).get(api_str, {}).get('status') != 'pass':
+                        unverified.append(cmd)  # Re-test failed commands
+                else:
+                    # For multi-version, check if any version needs testing
+                    needs_test = True
+                    for version in cmd.get('versions', []):
+                        if self.version_applies_to_api(version['range'], api_level):
+                            if version.get('verification', {}).get('testedVersions', {}).get(api_str, {}).get('status') == 'pass':
+                                needs_test = False
+                                break
+                    if needs_test:
+                        unverified.append(cmd)
+
+            commands_to_test = unverified
+            print(f"{Colors.CYAN}Found {len(commands_to_test)} unverified commands for API {api_level}{Colors.RESET}")
+
+        if not commands_to_test:
+            print(f"{Colors.GREEN}All commands already verified for API {api_level}!{Colors.RESET}")
+            return
+
+        total = len(commands_to_test)
+        print(f"\n{Colors.GREEN}Ready to test {total} commands on API {api_level}{Colors.RESET}")
+        input(f"{Colors.YELLOW}Press Enter to begin...{Colors.RESET}")
+
+        # Test each command
+        for i, cmd in enumerate(commands_to_test[start_from:], start=start_from + 1):
+            result = self.test_command(cmd, i, total)
+
+            if result:
+                # Check for consolidation opportunities in multi-version commands
+                if cmd.get('multiVersion'):
+                    self.suggest_version_consolidation(cmd['id'])
+
+                # Ask to save after each command
+                if self.get_save_permission():
+                    self.save_commands(create_backup=False)  # Don't backup every time
+                    print(f"{Colors.GREEN}✓ Progress saved{Colors.RESET}")
+
+            # Ask to continue
+            if i < total:
+                cont = input(f"\n{Colors.CYAN}Continue to next? [y/n/q]: {Colors.RESET}").lower()
+                if cont in ['q', 'quit']:
+                    break
+                elif cont in ['n', 'no']:
+                    print(f"{Colors.YELLOW}Paused at command {i}. Resume with --start-from {i}{Colors.RESET}")
+                    break
+
+        # Final save
+        self.display_session_summary()
+        if self.session_stats['tested'] > 0:
+            if self.get_save_permission():
+                self.save_commands()
+                print(f"{Colors.GREEN}✓ All changes saved{Colors.RESET}")
+
+        # Stop emulator
+        self.stop_emulator()
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Manual ADB Command Verifier',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python manual_verify.py --api 36                    # Test unverified commands on API 36
+  python manual_verify.py --api 35 --all              # Test ALL commands on API 35
+  python manual_verify.py --api 36 --category connection  # Test connection commands
+  python manual_verify.py --api 36 --start-from 10    # Resume from command 10
+        """
+    )
+
+    parser.add_argument('--api', type=int, required=True,
+                       choices=[31, 33, 34, 35, 36],
+                       help='API level to test (31=Android 12, 33=13, 34=14, 35=15, 36=16)')
+    parser.add_argument('--category',
+                       choices=['connection', 'installation', 'deviceinfo', 'troubleshooting'],
+                       help='Test specific category only')
+    parser.add_argument('--all', action='store_true',
+                       help='Test all commands, even if already verified')
+    parser.add_argument('--start-from', type=int, default=0,
+                       help='Start from command index (for resuming)')
+    parser.add_argument('--no-backup', action='store_true',
+                       help='Disable automatic backups')
+
+    args = parser.parse_args()
+
+    print(f"{Colors.BOLD}{Colors.CYAN}ADB Command Manual Verifier{Colors.RESET}")
+    print(f"{Colors.YELLOW}Testing on API Level {args.api}{Colors.RESET}")
+
+    verifier = ManualVerifier(auto_backup=not args.no_backup)
+
+    try:
+        verifier.run_verification(
+            api_level=args.api,
+            category=args.category,
+            test_all=args.all,
+            start_from=args.start_from
+        )
+    except KeyboardInterrupt:
+        print(f"\n{Colors.YELLOW}Interrupted by user{Colors.RESET}")
+        verifier.display_session_summary()
+        if verifier.session_stats['tested'] > 0:
+            if verifier.get_save_permission():
+                verifier.save_commands()
+                print(f"{Colors.GREEN}✓ Progress saved{Colors.RESET}")
+    except Exception as e:
+        print(f"{Colors.RED}Error: {e}{Colors.RESET}")
+        import traceback
+        traceback.print_exc()
+    finally:
+        if verifier.current_device:
+            verifier.stop_emulator()
+
+if __name__ == '__main__':
+    main()

--- a/tools/adb-cmd/utils/modules/__init__.py
+++ b/tools/adb-cmd/utils/modules/__init__.py
@@ -1,0 +1,13 @@
+"""
+ADB Verifier Modules
+"""
+
+from .emulator_manager import EmulatorManager, EmulatorInfo
+from .command_runner import CommandRunner, CommandResult
+
+__all__ = [
+    'EmulatorManager',
+    'EmulatorInfo',
+    'CommandRunner',
+    'CommandResult'
+]

--- a/tools/adb-cmd/utils/modules/command_runner.py
+++ b/tools/adb-cmd/utils/modules/command_runner.py
@@ -1,0 +1,536 @@
+"""
+Command Runner Module
+Executes ADB commands and captures output
+"""
+
+import asyncio
+import logging
+import subprocess
+import time
+from typing import Dict, List, Optional, Tuple
+from dataclasses import dataclass
+from datetime import datetime
+import re
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CommandResult:
+    """Result of command execution"""
+    command: str
+    success: bool
+    stdout: str
+    stderr: str
+    return_code: int
+    execution_time: float
+    timestamp: datetime
+    device_serial: str
+    api_level: Optional[int] = None
+    screenshot_path: Optional[str] = None
+
+
+class CommandRunner:
+    """Executes ADB commands and captures results"""
+
+    def __init__(self, timeout: int = 30, retry_attempts: int = 2):
+        """Initialize command runner"""
+        self.timeout = timeout
+        self.retry_attempts = retry_attempts
+        self.command_history = []
+
+    async def execute_command(self,
+                             command: str,
+                             serial: str,
+                             timeout: Optional[int] = None,
+                             capture_screenshot: bool = False) -> CommandResult:
+        """Execute a single ADB command"""
+        timeout = timeout or self.timeout
+
+        # Ensure command is properly formatted
+        command = self._format_command(command, serial)
+
+        logger.debug(f"Executing: {command}")
+
+        # Try execution with retries
+        for attempt in range(self.retry_attempts):
+            result = await self._run_command(command, serial, timeout)
+
+            if result.success or attempt == self.retry_attempts - 1:
+                break
+
+            logger.warning(f"Command failed (attempt {attempt + 1}/{self.retry_attempts}): {command}")
+            await asyncio.sleep(2)  # Wait before retry
+
+        # Capture screenshot if requested
+        if capture_screenshot:
+            screenshot_path = await self.capture_screenshot(serial)
+            result.screenshot_path = screenshot_path
+
+        # Store in history
+        self.command_history.append(result)
+
+        return result
+
+    def _format_command(self, command: str, serial: str) -> str:
+        """Format ADB command with device serial"""
+        # Remove any existing 'adb' prefix
+        if command.startswith('adb '):
+            command = command[4:]
+
+        # Check if serial is already specified
+        if '-s' in command:
+            return f"adb {command}"
+
+        # Add serial specification
+        return f"adb -s {serial} {command}"
+
+    async def _run_command(self,
+                          command: str,
+                          serial: str,
+                          timeout: int) -> CommandResult:
+        """Run command and capture output"""
+        start_time = time.time()
+
+        try:
+            # Run command
+            if isinstance(command, str):
+                process = await asyncio.create_subprocess_shell(
+                    command,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE
+                )
+            else:
+                process = await asyncio.create_subprocess_exec(
+                    *command,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE
+                )
+
+            # Wait for completion with timeout
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    process.communicate(),
+                    timeout=timeout
+                )
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.communicate()
+                raise subprocess.TimeoutExpired(command, timeout)
+
+            execution_time = time.time() - start_time
+
+            return CommandResult(
+                command=command,
+                success=(process.returncode == 0),
+                stdout=stdout.decode('utf-8', errors='replace'),
+                stderr=stderr.decode('utf-8', errors='replace'),
+                return_code=process.returncode,
+                execution_time=execution_time,
+                timestamp=datetime.now(),
+                device_serial=serial
+            )
+
+        except subprocess.TimeoutExpired:
+            execution_time = time.time() - start_time
+            return CommandResult(
+                command=command,
+                success=False,
+                stdout="",
+                stderr=f"Command timeout after {timeout} seconds",
+                return_code=-1,
+                execution_time=execution_time,
+                timestamp=datetime.now(),
+                device_serial=serial
+            )
+
+        except Exception as e:
+            execution_time = time.time() - start_time
+            return CommandResult(
+                command=command,
+                success=False,
+                stdout="",
+                stderr=str(e),
+                return_code=-1,
+                execution_time=execution_time,
+                timestamp=datetime.now(),
+                device_serial=serial
+            )
+
+    async def execute_shell_command(self,
+                                  shell_command: str,
+                                  serial: str,
+                                  as_root: bool = False) -> CommandResult:
+        """Execute a shell command on the device"""
+        if as_root:
+            command = f"shell su -c '{shell_command}'"
+        else:
+            command = f"shell {shell_command}"
+
+        return await self.execute_command(command, serial)
+
+    async def get_device_info(self, serial: str) -> Dict[str, str]:
+        """Get comprehensive device information"""
+        info = {
+            'serial': serial,
+            'model': '',
+            'manufacturer': '',
+            'android_version': '',
+            'api_level': '',
+            'build_id': '',
+            'screen_resolution': '',
+            'screen_density': ''
+        }
+
+        # Device properties to query
+        props = {
+            'model': 'ro.product.model',
+            'manufacturer': 'ro.product.manufacturer',
+            'android_version': 'ro.build.version.release',
+            'api_level': 'ro.build.version.sdk',
+            'build_id': 'ro.build.id'
+        }
+
+        for key, prop in props.items():
+            result = await self.execute_command(
+                f"shell getprop {prop}",
+                serial
+            )
+            if result.success:
+                info[key] = result.stdout.strip()
+
+        # Get screen info
+        result = await self.execute_command(
+            "shell wm size",
+            serial
+        )
+        if result.success and 'Physical size:' in result.stdout:
+            info['screen_resolution'] = result.stdout.split('Physical size:')[1].strip()
+
+        result = await self.execute_command(
+            "shell wm density",
+            serial
+        )
+        if result.success and 'Physical density:' in result.stdout:
+            info['screen_density'] = result.stdout.split('Physical density:')[1].strip()
+
+        return info
+
+    async def check_command_availability(self,
+                                        command: str,
+                                        serial: str) -> bool:
+        """Check if a command is available on the device"""
+        # For shell commands, check if binary exists
+        if command.startswith('shell '):
+            binary = command.split()[1]
+            result = await self.execute_command(
+                f"shell which {binary}",
+                serial
+            )
+            return result.success and result.stdout.strip()
+
+        # For other commands, try help or version flag
+        test_command = command.split()[0]
+        for flag in ['--help', '-h', '--version', '-v']:
+            result = await self.execute_command(
+                f"{test_command} {flag}",
+                serial
+            )
+            if result.success:
+                return True
+
+        return False
+
+    async def capture_screenshot(self, serial: str) -> Optional[str]:
+        """Capture a screenshot from the device"""
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        screenshot_path = f"/tmp/screenshot_{serial}_{timestamp}.png"
+
+        try:
+            # Capture screenshot on device
+            device_path = f"/sdcard/screenshot_{timestamp}.png"
+            result = await self.execute_command(
+                f"shell screencap -p {device_path}",
+                serial
+            )
+
+            if result.success:
+                # Pull screenshot to host
+                result = await self.execute_command(
+                    f"pull {device_path} {screenshot_path}",
+                    serial
+                )
+
+                if result.success:
+                    # Clean up device screenshot
+                    await self.execute_command(
+                        f"shell rm {device_path}",
+                        serial
+                    )
+                    logger.info(f"Screenshot captured: {screenshot_path}")
+                    return screenshot_path
+
+        except Exception as e:
+            logger.error(f"Failed to capture screenshot: {e}")
+
+        return None
+
+    async def install_apk(self,
+                         apk_path: str,
+                         serial: str,
+                         replace: bool = True) -> CommandResult:
+        """Install an APK on the device"""
+        flags = "-r" if replace else ""
+        return await self.execute_command(
+            f"install {flags} {apk_path}",
+            serial
+        )
+
+    async def uninstall_package(self,
+                               package_name: str,
+                               serial: str) -> CommandResult:
+        """Uninstall a package from the device"""
+        return await self.execute_command(
+            f"uninstall {package_name}",
+            serial
+        )
+
+    async def list_packages(self,
+                          serial: str,
+                          system_only: bool = False,
+                          third_party_only: bool = False) -> List[str]:
+        """List installed packages"""
+        flags = ""
+        if system_only:
+            flags = "-s"
+        elif third_party_only:
+            flags = "-3"
+
+        result = await self.execute_command(
+            f"shell pm list packages {flags}",
+            serial
+        )
+
+        packages = []
+        if result.success:
+            for line in result.stdout.split('\n'):
+                if line.startswith('package:'):
+                    packages.append(line.replace('package:', '').strip())
+
+        return packages
+
+    async def push_file(self,
+                       local_path: str,
+                       device_path: str,
+                       serial: str) -> CommandResult:
+        """Push a file to the device"""
+        return await self.execute_command(
+            f"push {local_path} {device_path}",
+            serial
+        )
+
+    async def pull_file(self,
+                       device_path: str,
+                       local_path: str,
+                       serial: str) -> CommandResult:
+        """Pull a file from the device"""
+        return await self.execute_command(
+            f"pull {device_path} {local_path}",
+            serial
+        )
+
+    async def forward_port(self,
+                         local_port: int,
+                         device_port: int,
+                         serial: str) -> CommandResult:
+        """Forward a port from host to device"""
+        return await self.execute_command(
+            f"forward tcp:{local_port} tcp:{device_port}",
+            serial
+        )
+
+    async def reverse_port(self,
+                          device_port: int,
+                          local_port: int,
+                          serial: str) -> CommandResult:
+        """Reverse a port from device to host"""
+        return await self.execute_command(
+            f"reverse tcp:{device_port} tcp:{local_port}",
+            serial
+        )
+
+    async def get_logcat(self,
+                        serial: str,
+                        lines: int = 100,
+                        filter_spec: Optional[str] = None) -> CommandResult:
+        """Get logcat output"""
+        command = f"logcat -d -t {lines}"
+        if filter_spec:
+            command += f" {filter_spec}"
+
+        return await self.execute_command(command, serial)
+
+    async def clear_logcat(self, serial: str) -> CommandResult:
+        """Clear logcat buffer"""
+        return await self.execute_command("logcat -c", serial)
+
+    async def set_property(self,
+                          prop_name: str,
+                          prop_value: str,
+                          serial: str) -> CommandResult:
+        """Set a system property"""
+        return await self.execute_shell_command(
+            f"setprop {prop_name} {prop_value}",
+            serial,
+            as_root=True
+        )
+
+    async def get_property(self,
+                          prop_name: str,
+                          serial: str) -> Optional[str]:
+        """Get a system property value"""
+        result = await self.execute_shell_command(
+            f"getprop {prop_name}",
+            serial
+        )
+
+        if result.success:
+            return result.stdout.strip()
+        return None
+
+    async def reboot_device(self,
+                          serial: str,
+                          mode: str = "") -> CommandResult:
+        """Reboot the device"""
+        if mode:
+            return await self.execute_command(f"reboot {mode}", serial)
+        return await self.execute_command("reboot", serial)
+
+    async def get_battery_info(self, serial: str) -> Dict[str, str]:
+        """Get battery information"""
+        result = await self.execute_shell_command(
+            "dumpsys battery",
+            serial
+        )
+
+        battery_info = {}
+        if result.success:
+            for line in result.stdout.split('\n'):
+                if ':' in line:
+                    key, value = line.split(':', 1)
+                    battery_info[key.strip()] = value.strip()
+
+        return battery_info
+
+    async def simulate_battery_level(self,
+                                   level: int,
+                                   serial: str) -> CommandResult:
+        """Simulate battery level (for testing)"""
+        return await self.execute_shell_command(
+            f"dumpsys battery set level {level}",
+            serial
+        )
+
+    async def get_network_info(self, serial: str) -> Dict[str, str]:
+        """Get network information"""
+        result = await self.execute_shell_command(
+            "dumpsys connectivity",
+            serial
+        )
+
+        network_info = {
+            'wifi_connected': False,
+            'mobile_connected': False,
+            'airplane_mode': False
+        }
+
+        if result.success:
+            if 'Wi-Fi is enabled' in result.stdout:
+                network_info['wifi_connected'] = True
+            if 'Mobile network is available' in result.stdout:
+                network_info['mobile_connected'] = True
+
+        # Check airplane mode
+        airplane = await self.get_property(
+            'persist.radio.airplane_mode_on',
+            serial
+        )
+        network_info['airplane_mode'] = airplane == '1'
+
+        return network_info
+
+    async def toggle_wifi(self,
+                         enable: bool,
+                         serial: str) -> CommandResult:
+        """Toggle WiFi on/off"""
+        action = "enable" if enable else "disable"
+        return await self.execute_shell_command(
+            f"svc wifi {action}",
+            serial,
+            as_root=True
+        )
+
+    async def input_text(self,
+                        text: str,
+                        serial: str) -> CommandResult:
+        """Input text to the device"""
+        # Escape special characters
+        escaped_text = text.replace(' ', '%s').replace("'", "\\'")
+        return await self.execute_shell_command(
+            f"input text '{escaped_text}'",
+            serial
+        )
+
+    async def input_tap(self,
+                       x: int,
+                       y: int,
+                       serial: str) -> CommandResult:
+        """Simulate a tap at coordinates"""
+        return await self.execute_shell_command(
+            f"input tap {x} {y}",
+            serial
+        )
+
+    async def input_swipe(self,
+                         x1: int, y1: int,
+                         x2: int, y2: int,
+                         duration: int,
+                         serial: str) -> CommandResult:
+        """Simulate a swipe gesture"""
+        return await self.execute_shell_command(
+            f"input swipe {x1} {y1} {x2} {y2} {duration}",
+            serial
+        )
+
+    async def input_keyevent(self,
+                           keycode: str,
+                           serial: str) -> CommandResult:
+        """Send a key event to the device"""
+        return await self.execute_shell_command(
+            f"input keyevent {keycode}",
+            serial
+        )
+
+    def get_command_history(self) -> List[CommandResult]:
+        """Get command execution history"""
+        return self.command_history
+
+    def clear_history(self):
+        """Clear command execution history"""
+        self.command_history.clear()
+
+    async def verify_output_pattern(self,
+                                  command: str,
+                                  serial: str,
+                                  expected_pattern: str) -> Tuple[bool, str]:
+        """Execute command and verify output matches expected pattern"""
+        result = await self.execute_command(command, serial)
+
+        if not result.success:
+            return False, f"Command failed: {result.stderr}"
+
+        # Check if pattern is found in output
+        if re.search(expected_pattern, result.stdout, re.IGNORECASE):
+            return True, "Pattern matched"
+
+        return False, f"Pattern not found. Output: {result.stdout[:200]}..."

--- a/tools/adb-cmd/utils/modules/emulator_manager.py
+++ b/tools/adb-cmd/utils/modules/emulator_manager.py
@@ -1,0 +1,681 @@
+"""
+Emulator Management Module
+Handles Android emulator lifecycle and configuration
+"""
+
+import asyncio
+import logging
+import subprocess
+import json
+import os
+import platform
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+from dataclasses import dataclass
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EmulatorInfo:
+    """Information about an emulator instance"""
+    name: str
+    serial: str
+    api_level: int
+    status: str  # starting, running, stopping, stopped
+    start_time: Optional[datetime] = None
+    process_id: Optional[int] = None
+
+
+class EmulatorManager:
+    """Manages Android emulator lifecycle"""
+
+    # Supported API levels (Android 12-16, skipping 32)
+    SUPPORTED_API_LEVELS = [31, 33, 34, 35, 36]
+
+    # API level to Android version mapping
+    API_VERSION_MAP = {
+        31: "12",
+        33: "13",
+        34: "14",
+        35: "15",
+        36: "16"
+    }
+
+    def __init__(self, config: Dict = None):
+        """Initialize emulator manager"""
+        self.config = config or {}
+        self.emulators = {}  # Track active emulators
+        self.headless = self.config.get('headless', True)
+        self.memory = self.config.get('memory', 2048)
+        self.gpu_mode = self.config.get('gpu_mode', 'auto')
+        self.setup_android_sdk_path()
+
+    def setup_android_sdk_path(self):
+        """Setup Android SDK paths in environment"""
+        is_mac = platform.system() == 'Darwin'
+
+        # Common Android SDK locations
+        sdk_paths = []
+
+        # Check environment variables
+        android_home = os.environ.get('ANDROID_HOME')
+        android_sdk_root = os.environ.get('ANDROID_SDK_ROOT')
+
+        if android_home:
+            sdk_paths.append(Path(android_home))
+        if android_sdk_root:
+            sdk_paths.append(Path(android_sdk_root))
+
+        # Check common locations
+        home = Path.home()
+        if is_mac:
+            sdk_paths.extend([
+                home / 'Library' / 'Android' / 'sdk',
+                Path('/usr/local/share/android-sdk'),
+                Path('/opt/android-sdk')
+            ])
+        else:  # Windows/Linux
+            sdk_paths.extend([
+                home / 'Android' / 'Sdk',
+                home / 'android-sdk',
+                Path('/opt/android-sdk')
+            ])
+
+        # Find the first existing SDK path
+        sdk_path = None
+        for path in sdk_paths:
+            if path.exists():
+                sdk_path = path
+                break
+
+        if sdk_path:
+            # Add SDK tools to PATH
+            emulator_path = sdk_path / 'emulator'
+            platform_tools = sdk_path / 'platform-tools'
+            cmdline_tools = sdk_path / 'cmdline-tools' / 'latest' / 'bin'
+            tools = sdk_path / 'tools' / 'bin'
+
+            paths_to_add = []
+            if emulator_path.exists():
+                paths_to_add.append(str(emulator_path))
+            if platform_tools.exists():
+                paths_to_add.append(str(platform_tools))
+            if cmdline_tools.exists():
+                paths_to_add.append(str(cmdline_tools))
+            if tools.exists():
+                paths_to_add.append(str(tools))
+
+            if paths_to_add:
+                current_path = os.environ.get('PATH', '')
+                new_path = os.pathsep.join(paths_to_add + [current_path])
+                os.environ['PATH'] = new_path
+                logger.info(f"Android SDK found at: {sdk_path}")
+
+            # Also set ANDROID_HOME if not set
+            if not android_home:
+                os.environ['ANDROID_HOME'] = str(sdk_path)
+        else:
+            logger.warning("Android SDK not found. Please set ANDROID_HOME environment variable.")
+
+    async def check_prerequisites(self) -> Dict[str, bool]:
+        """Check if all prerequisites are met"""
+        checks = {
+            'adb': False,
+            'emulator': False,
+            'avdmanager': False,
+            'sdkmanager': False
+        }
+
+        # Get SDK path from environment
+        sdk_path = Path(os.environ.get('ANDROID_HOME', ''))
+        if not sdk_path.exists():
+            sdk_path = Path.home() / 'Library' / 'Android' / 'sdk'
+
+        # Check tools with their full paths
+        tool_paths = {
+            'adb': 'adb',  # Usually in PATH
+            'emulator': str(sdk_path / 'emulator' / 'emulator'),
+            'avdmanager': str(sdk_path / 'cmdline-tools' / 'latest' / 'bin' / 'avdmanager'),
+            'sdkmanager': str(sdk_path / 'cmdline-tools' / 'latest' / 'bin' / 'sdkmanager')
+        }
+
+        for tool, path in tool_paths.items():
+            try:
+                # Try with full path first
+                cmd = [path, '--version'] if tool != 'adb' else [path, 'version']
+                result = subprocess.run(cmd, capture_output=True, timeout=5)
+                checks[tool] = result.returncode == 0 or Path(path).exists()
+
+                # If failed, try without path
+                if not checks[tool] and tool in ['adb', 'sdkmanager']:
+                    cmd = [tool, '--version'] if tool != 'adb' else [tool, 'version']
+                    result = subprocess.run(cmd, capture_output=True, timeout=5)
+                    checks[tool] = result.returncode == 0
+            except Exception:
+                # Check if the file at least exists
+                if Path(path).exists():
+                    checks[tool] = True
+                else:
+                    checks[tool] = False
+
+        return checks
+
+    async def download_system_image(self, api_level: int) -> bool:
+        """Download system image for specified API level"""
+        if api_level not in self.SUPPORTED_API_LEVELS:
+            logger.error(f"Unsupported API level: {api_level}")
+            return False
+
+        system_image = f"system-images;android-{api_level};google_apis;arm64-v8a"
+        logger.info(f"Downloading system image: {system_image}")
+
+        try:
+            # Accept licenses first
+            accept_cmd = subprocess.Popen(
+                ['yes'],
+                stdout=subprocess.PIPE
+            )
+
+            # Use full path to sdkmanager
+            sdk_path = Path(os.environ.get('ANDROID_HOME', Path.home() / 'Library' / 'Android' / 'sdk'))
+            sdkmanager_path = sdk_path / 'cmdline-tools' / 'latest' / 'bin' / 'sdkmanager'
+
+            result = subprocess.run(
+                [str(sdkmanager_path), '--licenses'],
+                stdin=accept_cmd.stdout,
+                capture_output=True,
+                timeout=30
+            )
+
+            # Download system image
+            result = subprocess.run(
+                [str(sdkmanager_path), system_image],
+                capture_output=True,
+                text=True,
+                timeout=600  # 10 minutes timeout
+            )
+
+            if result.returncode == 0:
+                logger.info(f"System image downloaded: {system_image}")
+                return True
+            else:
+                if "already installed" in result.stderr.lower():
+                    logger.info(f"System image already installed: {system_image}")
+                    return True
+                logger.error(f"Failed to download system image: {result.stderr}")
+                return False
+
+        except subprocess.TimeoutExpired:
+            logger.error("Timeout downloading system image")
+            return False
+        except Exception as e:
+            logger.error(f"Error downloading system image: {e}")
+            return False
+
+    async def create_avd(self,
+                        name: str,
+                        api_level: int,
+                        device_type: str = "pixel_5") -> bool:
+        """Create an Android Virtual Device"""
+        if api_level not in self.SUPPORTED_API_LEVELS:
+            logger.error(f"Unsupported API level: {api_level}")
+            return False
+
+        logger.info(f"Creating AVD: {name} (API {api_level})")
+
+        # Ensure system image is available
+        if not await self.download_system_image(api_level):
+            return False
+
+        # Create AVD command with full path
+        sdk_path = Path(os.environ.get('ANDROID_HOME', Path.home() / 'Library' / 'Android' / 'sdk'))
+        avdmanager_path = sdk_path / 'cmdline-tools' / 'latest' / 'bin' / 'avdmanager'
+
+        cmd = [
+            str(avdmanager_path), 'create', 'avd',
+            '-n', name,
+            '-k', f"system-images;android-{api_level};google_apis;arm64-v8a",
+            '-d', device_type,
+            '--force'
+        ]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                input='\n',  # Default hardware profile
+                timeout=30
+            )
+
+            if result.returncode == 0:
+                logger.info(f"AVD created: {name}")
+
+                # Configure AVD properties
+                await self._configure_avd(name)
+                return True
+            else:
+                logger.error(f"Failed to create AVD: {result.stderr}")
+                return False
+
+        except Exception as e:
+            logger.error(f"Error creating AVD: {e}")
+            return False
+
+    async def _configure_avd(self, name: str):
+        """Configure AVD properties for testing"""
+        avd_path = Path.home() / ".android" / "avd" / f"{name}.avd"
+        config_file = avd_path / "config.ini"
+
+        if not config_file.exists():
+            logger.warning(f"AVD config file not found: {config_file}")
+            return
+
+        try:
+            # Read current config
+            with open(config_file, 'r') as f:
+                lines = f.readlines()
+
+            # Update config
+            config_updates = {
+                'hw.ramSize': str(self.memory),
+                'hw.gpu.enabled': 'yes',
+                'hw.gpu.mode': self.gpu_mode,
+                'hw.keyboard': 'yes',
+                'hw.accelerometer': 'yes',
+                'hw.battery': 'yes',
+                'hw.camera.back': 'virtualscene',
+                'hw.camera.front': 'emulated',
+                'showDeviceFrame': 'no' if self.headless else 'yes'
+            }
+
+            # Apply updates
+            updated_lines = []
+            updated_keys = set()
+
+            for line in lines:
+                if '=' in line:
+                    key = line.split('=')[0].strip()
+                    if key in config_updates:
+                        updated_lines.append(f"{key}={config_updates[key]}\n")
+                        updated_keys.add(key)
+                    else:
+                        updated_lines.append(line)
+                else:
+                    updated_lines.append(line)
+
+            # Add missing configurations
+            for key, value in config_updates.items():
+                if key not in updated_keys:
+                    updated_lines.append(f"{key}={value}\n")
+
+            # Write updated config
+            with open(config_file, 'w') as f:
+                f.writelines(updated_lines)
+
+            logger.info(f"AVD configured: {name}")
+
+        except Exception as e:
+            logger.error(f"Failed to configure AVD: {e}")
+
+    async def delete_avd(self, name: str) -> bool:
+        """Delete an AVD"""
+        logger.info(f"Deleting AVD: {name}")
+
+        try:
+            # Use full path to avdmanager
+            sdk_path = Path(os.environ.get('ANDROID_HOME', Path.home() / 'Library' / 'Android' / 'sdk'))
+            avdmanager_path = sdk_path / 'cmdline-tools' / 'latest' / 'bin' / 'avdmanager'
+
+            result = subprocess.run(
+                [str(avdmanager_path), 'delete', 'avd', '-n', name],
+                capture_output=True,
+                text=True,
+                timeout=30
+            )
+
+            if result.returncode == 0:
+                logger.info(f"AVD deleted: {name}")
+                return True
+            else:
+                logger.error(f"Failed to delete AVD: {result.stderr}")
+                return False
+
+        except Exception as e:
+            logger.error(f"Error deleting AVD: {e}")
+            return False
+
+    async def list_avds(self) -> List[Dict[str, str]]:
+        """List all available AVDs with details"""
+        try:
+            # Use full path to emulator
+            sdk_path = Path(os.environ.get('ANDROID_HOME', Path.home() / 'Library' / 'Android' / 'sdk'))
+            emulator_path = sdk_path / 'emulator' / 'emulator'
+
+            result = subprocess.run(
+                [str(emulator_path), '-list-avds'],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+
+            if result.returncode == 0:
+                avd_names = [name.strip() for name in result.stdout.strip().split('\n') if name]
+
+                avds = []
+                for name in avd_names:
+                    # Get AVD info
+                    info = await self._get_avd_info(name)
+                    if info:
+                        avds.append(info)
+
+                return avds
+            return []
+
+        except Exception as e:
+            logger.error(f"Error listing AVDs: {e}")
+            return []
+
+    async def _get_avd_info(self, name: str) -> Optional[Dict[str, str]]:
+        """Get detailed information about an AVD"""
+        avd_path = Path.home() / ".android" / "avd" / f"{name}.avd"
+        config_file = avd_path / "config.ini"
+
+        if not config_file.exists():
+            return None
+
+        try:
+            with open(config_file, 'r') as f:
+                config = {}
+                for line in f:
+                    if '=' in line:
+                        key, value = line.strip().split('=', 1)
+                        config[key] = value
+
+            # Extract API level from image path
+            image_path = config.get('image.sysdir.1', '')
+            api_level = None
+            if 'android-' in image_path:
+                try:
+                    api_level = int(image_path.split('android-')[1].split('/')[0])
+                except Exception:
+                    pass
+
+            return {
+                'name': name,
+                'path': str(avd_path),
+                'api_level': api_level,
+                'android_version': self.API_VERSION_MAP.get(api_level, 'Unknown'),
+                'ram': config.get('hw.ramSize', 'Unknown'),
+                'device': config.get('hw.device.name', 'Unknown')
+            }
+
+        except Exception as e:
+            logger.error(f"Error reading AVD info: {e}")
+            return None
+
+    async def start_emulator(self,
+                           avd_name: str,
+                           port: Optional[int] = None,
+                           snapshot: Optional[str] = None) -> Optional[EmulatorInfo]:
+        """Start an emulator instance"""
+        logger.info(f"Starting emulator: {avd_name}")
+
+        # Check if AVD exists
+        avds = await self.list_avds()
+        avd_info = next((avd for avd in avds if avd['name'] == avd_name), None)
+
+        if not avd_info:
+            logger.error(f"AVD not found: {avd_name}")
+            return None
+
+        # Build emulator command with full path
+        sdk_path = Path(os.environ.get('ANDROID_HOME', Path.home() / 'Library' / 'Android' / 'sdk'))
+        emulator_path = sdk_path / 'emulator' / 'emulator'
+        cmd = [str(emulator_path), '-avd', avd_name]
+
+        if self.headless:
+            cmd.extend(['-no-window', '-no-audio', '-no-boot-anim'])
+
+        if port:
+            cmd.extend(['-port', str(port)])
+
+        if snapshot:
+            cmd.extend(['-snapshot', snapshot])
+
+        # Additional optimizations
+        cmd.extend([
+            '-no-snapshot-save',  # Don't save snapshot on exit
+            '-noaudio',
+            '-no-boot-anim',
+            '-accel', 'on',
+            '-gpu', self.gpu_mode,
+            '-memory', str(self.memory)
+        ])
+
+        try:
+            # Get current devices before starting
+            devices_before = await self._get_connected_devices()
+
+            # Start emulator process
+            process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE
+            )
+
+            # Wait for emulator to appear
+            serial = await self._wait_for_new_device(devices_before, timeout=120)
+
+            if serial:
+                emulator = EmulatorInfo(
+                    name=avd_name,
+                    serial=serial,
+                    api_level=avd_info.get('api_level', 0),
+                    status='starting',
+                    start_time=datetime.now(),
+                    process_id=process.pid
+                )
+
+                self.emulators[serial] = emulator
+
+                # Wait for boot
+                if await self._wait_for_boot(serial):
+                    emulator.status = 'running'
+                    logger.info(f"Emulator started: {serial}")
+                    return emulator
+                else:
+                    logger.error(f"Emulator failed to boot: {serial}")
+                    await self.stop_emulator(serial)
+                    return None
+            else:
+                logger.error("Timeout waiting for emulator to start")
+                process.terminate()
+                return None
+
+        except Exception as e:
+            logger.error(f"Error starting emulator: {e}")
+            return None
+
+    async def _get_connected_devices(self) -> List[str]:
+        """Get list of connected device serials"""
+        try:
+            result = subprocess.run(
+                ['adb', 'devices'],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+
+            devices = []
+            if result.returncode == 0:
+                lines = result.stdout.strip().split('\n')[1:]  # Skip header
+                for line in lines:
+                    if line and '\t' in line:
+                        serial, state = line.split('\t')
+                        if state == 'device':
+                            devices.append(serial)
+
+            return devices
+
+        except Exception as e:
+            logger.error(f"Error getting devices: {e}")
+            return []
+
+    async def _wait_for_new_device(self,
+                                  devices_before: List[str],
+                                  timeout: int = 120) -> Optional[str]:
+        """Wait for a new device to appear"""
+        check_interval = 2
+        waited = 0
+
+        while waited < timeout:
+            await asyncio.sleep(check_interval)
+            waited += check_interval
+
+            current_devices = await self._get_connected_devices()
+            new_devices = set(current_devices) - set(devices_before)
+
+            if new_devices:
+                return list(new_devices)[0]
+
+        return None
+
+    async def _wait_for_boot(self, serial: str, timeout: int = 120) -> bool:
+        """Wait for device to fully boot"""
+        logger.info(f"Waiting for {serial} to boot...")
+
+        check_interval = 3
+        waited = 0
+
+        while waited < timeout:
+            # Check boot completed
+            result = subprocess.run(
+                ['adb', '-s', serial, 'shell', 'getprop', 'sys.boot_completed'],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+
+            if result.returncode == 0 and result.stdout.strip() == '1':
+                # Also check if package manager is ready
+                result = subprocess.run(
+                    ['adb', '-s', serial, 'shell', 'pm', 'list', 'packages'],
+                    capture_output=True,
+                    timeout=5
+                )
+
+                if result.returncode == 0:
+                    logger.info(f"Device {serial} booted successfully")
+                    return True
+
+            await asyncio.sleep(check_interval)
+            waited += check_interval
+
+        logger.error(f"Timeout waiting for {serial} to boot")
+        return False
+
+    async def stop_emulator(self, serial: str) -> bool:
+        """Stop an emulator"""
+        logger.info(f"Stopping emulator: {serial}")
+
+        try:
+            # Try graceful shutdown
+            result = subprocess.run(
+                ['adb', '-s', serial, 'emu', 'kill'],
+                capture_output=True,
+                timeout=10
+            )
+
+            if serial in self.emulators:
+                emulator = self.emulators[serial]
+                emulator.status = 'stopped'
+
+                # Kill process if still running
+                if emulator.process_id:
+                    try:
+                        subprocess.run(['kill', str(emulator.process_id)])
+                    except Exception:
+                        pass
+
+                del self.emulators[serial]
+
+            logger.info(f"Emulator stopped: {serial}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Error stopping emulator: {e}")
+            return False
+
+    async def stop_all_emulators(self):
+        """Stop all running emulators"""
+        serials = list(self.emulators.keys())
+        for serial in serials:
+            await self.stop_emulator(serial)
+
+    async def take_snapshot(self, serial: str, name: str) -> bool:
+        """Take a snapshot of emulator state"""
+        logger.info(f"Taking snapshot: {name} for {serial}")
+
+        try:
+            result = subprocess.run(
+                ['adb', '-s', serial, 'emu', 'avd', 'snapshot', 'save', name],
+                capture_output=True,
+                text=True,
+                timeout=30
+            )
+
+            if result.returncode == 0:
+                logger.info(f"Snapshot saved: {name}")
+                return True
+            else:
+                logger.error(f"Failed to save snapshot: {result.stderr}")
+                return False
+
+        except Exception as e:
+            logger.error(f"Error saving snapshot: {e}")
+            return False
+
+    async def restore_snapshot(self, serial: str, name: str) -> bool:
+        """Restore emulator from snapshot"""
+        logger.info(f"Restoring snapshot: {name} for {serial}")
+
+        try:
+            result = subprocess.run(
+                ['adb', '-s', serial, 'emu', 'avd', 'snapshot', 'load', name],
+                capture_output=True,
+                text=True,
+                timeout=30
+            )
+
+            if result.returncode == 0:
+                logger.info(f"Snapshot restored: {name}")
+                return True
+            else:
+                logger.error(f"Failed to restore snapshot: {result.stderr}")
+                return False
+
+        except Exception as e:
+            logger.error(f"Error restoring snapshot: {e}")
+            return False
+
+    async def cleanup_test_avds(self, prefix: str = "test_android_"):
+        """Clean up test AVDs"""
+        logger.info("Cleaning up test AVDs...")
+
+        avds = await self.list_avds()
+        for avd in avds:
+            if avd['name'].startswith(prefix):
+                await self.delete_avd(avd['name'])
+
+        logger.info("Cleanup complete")
+
+    def get_emulator_info(self, serial: str) -> Optional[EmulatorInfo]:
+        """Get information about a running emulator"""
+        return self.emulators.get(serial)
+
+    def list_running_emulators(self) -> List[EmulatorInfo]:
+        """List all running emulators"""
+        return list(self.emulators.values())

--- a/tools/adb-cmd/utils/test_sdk_path.py
+++ b/tools/adb-cmd/utils/test_sdk_path.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Test if Android SDK tools can be found"""
+
+import subprocess
+import os
+from pathlib import Path
+import platform
+
+# ANSI colors
+GREEN = '\033[92m'
+RED = '\033[91m'
+YELLOW = '\033[93m'
+RESET = '\033[0m'
+
+def setup_android_sdk_path():
+    """Setup Android SDK paths in environment"""
+    is_mac = platform.system() == 'Darwin'
+
+    # Common Android SDK locations
+    sdk_paths = []
+
+    # Check environment variables
+    android_home = os.environ.get('ANDROID_HOME')
+    android_sdk_root = os.environ.get('ANDROID_SDK_ROOT')
+
+    if android_home:
+        sdk_paths.append(Path(android_home))
+    if android_sdk_root:
+        sdk_paths.append(Path(android_sdk_root))
+
+    # Check common locations
+    home = Path.home()
+    if is_mac:
+        sdk_paths.extend([
+            home / 'Library' / 'Android' / 'sdk',
+            Path('/usr/local/share/android-sdk'),
+            Path('/opt/android-sdk')
+        ])
+    else:
+        sdk_paths.extend([
+            home / 'Android' / 'Sdk',
+            home / 'android-sdk',
+            Path('/opt/android-sdk')
+        ])
+
+    # Find the first existing SDK path
+    sdk_path = None
+    for path in sdk_paths:
+        if path.exists():
+            sdk_path = path
+            print(f"{GREEN}✓ Found Android SDK at: {sdk_path}{RESET}")
+            break
+
+    if not sdk_path:
+        print(f"{RED}✗ Android SDK not found in common locations{RESET}")
+        return False
+
+    # Check for SDK subdirectories
+    dirs_to_check = {
+        'emulator': sdk_path / 'emulator',
+        'platform-tools': sdk_path / 'platform-tools',
+        'cmdline-tools': sdk_path / 'cmdline-tools' / 'latest' / 'bin',
+        'tools': sdk_path / 'tools' / 'bin'
+    }
+
+    paths_to_add = []
+    for name, path in dirs_to_check.items():
+        if path.exists():
+            print(f"  {GREEN}✓ Found {name} at: {path}{RESET}")
+            paths_to_add.append(str(path))
+        else:
+            print(f"  {YELLOW}⚠ {name} not found at: {path}{RESET}")
+
+    # Update PATH
+    if paths_to_add:
+        current_path = os.environ.get('PATH', '')
+        new_path = os.pathsep.join(paths_to_add + [current_path])
+        os.environ['PATH'] = new_path
+
+        # Set ANDROID_HOME if not set
+        if not android_home:
+            os.environ['ANDROID_HOME'] = str(sdk_path)
+
+        return True
+
+    return False
+
+def test_command(cmd, name):
+    """Test if a command can be found and executed"""
+    try:
+        result = subprocess.run(
+            [cmd, '--version'] if cmd != 'adb' else [cmd, 'version'],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode == 0:
+            print(f"{GREEN}✓ {name}: Found and working{RESET}")
+            return True
+        else:
+            print(f"{RED}✗ {name}: Found but returned error{RESET}")
+            return False
+    except FileNotFoundError:
+        print(f"{RED}✗ {name}: Not found in PATH{RESET}")
+        return False
+    except Exception as e:
+        print(f"{RED}✗ {name}: Error - {e}{RESET}")
+        return False
+
+def main():
+    print("=== Android SDK Path Test ===\n")
+
+    # Test before setup
+    print("Before PATH setup:")
+    tools = {
+        'adb': 'ADB',
+        'emulator': 'Emulator',
+        'avdmanager': 'AVD Manager',
+        'sdkmanager': 'SDK Manager'
+    }
+
+    before_results = {}
+    for cmd, name in tools.items():
+        before_results[cmd] = test_command(cmd, name)
+
+    print("\n" + "="*30 + "\n")
+
+    # Setup paths
+    print("Setting up Android SDK paths...")
+    if setup_android_sdk_path():
+        print(f"\n{GREEN}✓ PATH setup completed{RESET}\n")
+    else:
+        print(f"\n{YELLOW}⚠ PATH setup incomplete{RESET}\n")
+
+    # Test after setup
+    print("After PATH setup:")
+    after_results = {}
+    for cmd, name in tools.items():
+        after_results[cmd] = test_command(cmd, name)
+
+    # Summary
+    print("\n" + "="*30)
+    print("Summary:")
+    improved = []
+    still_missing = []
+
+    for cmd in tools:
+        if not before_results[cmd] and after_results[cmd]:
+            improved.append(cmd)
+        elif not after_results[cmd]:
+            still_missing.append(cmd)
+
+    if improved:
+        print(f"{GREEN}✓ Now working: {', '.join(improved)}{RESET}")
+
+    if still_missing:
+        print(f"{RED}✗ Still missing: {', '.join(still_missing)}{RESET}")
+        print(f"\n{YELLOW}To fix missing tools:{RESET}")
+        print("1. Install Android Studio and Android SDK")
+        print("2. Set ANDROID_HOME environment variable")
+        print("3. Install missing SDK components via Android Studio SDK Manager")
+    else:
+        print(f"{GREEN}✓ All tools are working!{RESET}")
+
+if __name__ == '__main__':
+    main()

--- a/tools/adb-cmd/utils/update_commands_structure.py
+++ b/tools/adb-cmd/utils/update_commands_structure.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Script to update commands.json structure with verification fields
+"""
+
+import json
+from pathlib import Path
+from datetime import datetime
+
+def add_verification_structure(commands):
+    """Add verification structure to all commands"""
+    updated_commands = []
+
+    for cmd in commands:
+        # Skip if already has verification (commands 1-3 already updated)
+        if cmd['id'] <= 3:
+            updated_commands.append(cmd)
+            continue
+
+        # Handle multiVersion commands
+        if cmd.get('multiVersion'):
+            # Add verification to each version
+            if 'versions' in cmd:
+                for version in cmd['versions']:
+                    if 'verification' not in version:
+                        version['verification'] = {
+                            "verified": False,
+                            "lastTested": None,
+                            "testedVersions": {}
+                        }
+
+            # Add overall verification
+            if 'verification' not in cmd:
+                cmd['verification'] = {
+                    "verified": False,
+                    "lastTested": None,
+                    "overallStatus": "untested"
+                }
+        else:
+            # Standard command - add simple verification
+            if 'verification' not in cmd:
+                cmd['verification'] = {
+                    "verified": False,
+                    "lastTested": None,
+                    "testedVersions": {}
+                }
+
+        updated_commands.append(cmd)
+
+    return updated_commands
+
+def create_backup(file_path):
+    """Create timestamped backup of commands.json"""
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    backup_dir = file_path.parent / 'backups'
+    backup_dir.mkdir(exist_ok=True)
+
+    backup_file = backup_dir / f'commands_{timestamp}.json'
+
+    with open(file_path, 'r') as f:
+        content = f.read()
+
+    with open(backup_file, 'w') as f:
+        f.write(content)
+
+    print(f"Backup created: {backup_file}")
+    return backup_file
+
+def main():
+    # Path to commands.json
+    commands_file = Path(__file__).parent.parent / 'data' / 'commands.json'
+
+    if not commands_file.exists():
+        print(f"Error: {commands_file} not found")
+        return
+
+    # Create backup first
+    backup_file = create_backup(commands_file)
+
+    # Load current commands
+    with open(commands_file, 'r') as f:
+        commands = json.load(f)
+
+    # Add verification structure
+    updated_commands = add_verification_structure(commands)
+
+    # Save updated commands
+    with open(commands_file, 'w') as f:
+        json.dump(updated_commands, f, indent=2)
+
+    print(f"✓ Updated {len(updated_commands)} commands with verification structure")
+    print(f"✓ Original backed up to: {backup_file}")
+
+    # Show summary
+    standard_count = sum(1 for cmd in updated_commands if not cmd.get('multiVersion'))
+    multi_count = sum(1 for cmd in updated_commands if cmd.get('multiVersion'))
+    print(f"\nCommand Summary:")
+    print(f"  - Standard commands: {standard_count}")
+    print(f"  - Multi-version commands: {multi_count}")
+    print(f"  - Total: {len(updated_commands)}")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Major updates to the ADB debugging commands tool:

- Removed Android 11 and lower version information from all commands
- Updated verification status to indicate only Android 12+ will be verified
- Added API 32 (Android 12L) to the API level mapping
- Removed deprecated "partial" verification status badge
- Cleaned up multi-version commands to focus on modern Android versions

Community contributions:
- Added GitHub issue templates for bug reports and new command requests
- Added direct links in the UI to report issues or suggest new commands
- Created contribution section with easy access buttons

Technical improvements:
- Added Python utilities for command verification and testing
- Created backup of original commands.json
- Added .gitignore to exclude venv, cache, and local settings